### PR TITLE
fix: re-order groups after api responses

### DIFF
--- a/internal/provider/env/aws/model.go
+++ b/internal/provider/env/aws/model.go
@@ -310,3 +310,18 @@ func maintenanceWindowsToModel(input []*sdk.AWSEnvSpecFragment_MaintenanceWindow
 
 	return maintenanceWindow
 }
+
+func reorderNodeGroups(model []common.NodeGroupsModel, sdk []*client.AWSEnvSpecFragment_NodeGroups) []*client.AWSEnvSpecFragment_NodeGroups {
+	orderedNodeGroups := make([]*client.AWSEnvSpecFragment_NodeGroups, 0, len(sdk))
+
+	for _, ng := range model {
+		for _, apiGroup := range sdk {
+			if ng.NodeType.ValueString() == apiGroup.NodeType {
+				orderedNodeGroups = append(orderedNodeGroups, apiGroup)
+				break
+			}
+		}
+	}
+
+	return orderedNodeGroups
+}

--- a/internal/provider/env/aws/resource.go
+++ b/internal/provider/env/aws/resource.go
@@ -48,13 +48,14 @@ func (r *AWSEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.CreateAWSEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.CreateAWSEnv.Spec.NodeGroups)
 	data.Id = data.Name
 	data.Zones = common.ListToModel(apiResp.CreateAWSEnv.Spec.Zones)
 	data.NodeGroups = nodeGroupsToModel(apiResp.CreateAWSEnv.Spec.NodeGroups)
 	data.SpecRevision = types.Int64Value(apiResp.CreateAWSEnv.SpecRevision)
 
 	tflog.Trace(ctx, "created resource", map[string]interface{}{"name": envName})
-
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
@@ -82,8 +83,11 @@ func (r *AWSEnvResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.AwsEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.AwsEnv.Spec.NodeGroups)
 	data.toModel(*apiResp.AwsEnv)
 	data.Id = data.Name
+
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
@@ -108,12 +112,13 @@ func (r *AWSEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": envName})
-
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.UpdateAWSEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.UpdateAWSEnv.Spec.NodeGroups)
 	data.Zones = common.ListToModel(apiResp.UpdateAWSEnv.Spec.Zones)
 	data.NodeGroups = nodeGroupsToModel(apiResp.UpdateAWSEnv.Spec.NodeGroups)
 	data.SpecRevision = types.Int64Value(apiResp.UpdateAWSEnv.SpecRevision)
 
+	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": envName})
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/env/azure/model.go
+++ b/internal/provider/env/azure/model.go
@@ -256,3 +256,18 @@ func maintenanceWindowsToModel(input []*client.AzureEnvSpecFragment_MaintenanceW
 
 	return maintenanceWindow
 }
+
+func reorderNodeGroups(model []common.NodeGroupsModel, sdk []*client.AzureEnvSpecFragment_NodeGroups) []*client.AzureEnvSpecFragment_NodeGroups {
+	orderedNodeGroups := make([]*client.AzureEnvSpecFragment_NodeGroups, 0, len(sdk))
+
+	for _, ng := range model {
+		for _, apiGroup := range sdk {
+			if ng.NodeType.ValueString() == apiGroup.NodeType {
+				orderedNodeGroups = append(orderedNodeGroups, apiGroup)
+				break
+			}
+		}
+	}
+
+	return orderedNodeGroups
+}

--- a/internal/provider/env/azure/resource.go
+++ b/internal/provider/env/azure/resource.go
@@ -49,12 +49,14 @@ func (r *AzureEnvResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	tflog.Trace(ctx, "created resource", map[string]interface{}{"name": name})
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.CreateAzureEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.CreateAzureEnv.Spec.NodeGroups)
 	data.Id = data.Name
 	data.Zones = common.ListToModel(apiResp.CreateAzureEnv.Spec.Zones)
 	data.NodeGroups = nodeGroupsToModel(apiResp.CreateAzureEnv.Spec.NodeGroups)
 	data.SpecRevision = types.Int64Value(apiResp.CreateAzureEnv.SpecRevision)
 
+	tflog.Trace(ctx, "created resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
@@ -83,8 +85,11 @@ func (r *AzureEnvResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.AzureEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.AzureEnv.Spec.NodeGroups)
 	data.toModel(*apiResp.AzureEnv)
 	data.Id = data.Name
+
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
@@ -109,11 +114,13 @@ func (r *AzureEnvResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": name})
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.UpdateAzureEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.UpdateAzureEnv.Spec.NodeGroups)
 	data.Zones = common.ListToModel(apiResp.UpdateAzureEnv.Spec.Zones)
 	data.NodeGroups = nodeGroupsToModel(apiResp.UpdateAzureEnv.Spec.NodeGroups)
 	data.SpecRevision = types.Int64Value(apiResp.UpdateAzureEnv.SpecRevision)
 
+	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/env/gcp/model.go
+++ b/internal/provider/env/gcp/model.go
@@ -210,3 +210,18 @@ func maintenanceWindowsToModel(input []*client.GCPEnvSpecFragment_MaintenanceWin
 
 	return maintenanceWindow
 }
+
+func reorderNodeGroups(model []common.NodeGroupsModel, sdk []*client.GCPEnvSpecFragment_NodeGroups) []*client.GCPEnvSpecFragment_NodeGroups {
+	orderedNodeGroups := make([]*client.GCPEnvSpecFragment_NodeGroups, 0, len(sdk))
+
+	for _, ng := range model {
+		for _, apiGroup := range sdk {
+			if ng.NodeType.ValueString() == apiGroup.NodeType {
+				orderedNodeGroups = append(orderedNodeGroups, apiGroup)
+				break
+			}
+		}
+	}
+
+	return orderedNodeGroups
+}

--- a/internal/provider/env/gcp/resource.go
+++ b/internal/provider/env/gcp/resource.go
@@ -49,12 +49,14 @@ func (r *GCPEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	tflog.Trace(ctx, "created resource", map[string]interface{}{"name": name})
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.CreateGCPEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.CreateGCPEnv.Spec.NodeGroups)
 	data.Id = data.Name
 	data.Zones = common.ListToModel(apiResp.CreateGCPEnv.Spec.Zones)
 	data.NodeGroups = nodeGroupsToModel(apiResp.CreateGCPEnv.Spec.NodeGroups)
 	data.SpecRevision = types.Int64Value(apiResp.CreateGCPEnv.SpecRevision)
 
+	tflog.Trace(ctx, "created resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
@@ -83,8 +85,11 @@ func (r *GCPEnvResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.GcpEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.GcpEnv.Spec.NodeGroups)
 	data.toModel(*apiResp.GcpEnv)
 	data.Id = data.Name
+
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
@@ -109,11 +114,13 @@ func (r *GCPEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": name})
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.UpdateGCPEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.UpdateGCPEnv.Spec.NodeGroups)
 	data.Zones = common.ListToModel(apiResp.UpdateGCPEnv.Spec.Zones)
 	data.NodeGroups = nodeGroupsToModel(apiResp.UpdateGCPEnv.Spec.NodeGroups)
 	data.SpecRevision = types.Int64Value(apiResp.UpdateGCPEnv.SpecRevision)
 
+	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/env/hcloud/model.go
+++ b/internal/provider/env/hcloud/model.go
@@ -253,3 +253,18 @@ func wireguardPeersToModel(input []*client.HCloudEnvSpecFragment_WireguardPeers)
 
 	return peers
 }
+
+func reorderNodeGroups(model []NodeGroupsModel, sdk []*client.HCloudEnvSpecFragment_NodeGroups) []*client.HCloudEnvSpecFragment_NodeGroups {
+	orderedNodeGroups := make([]*client.HCloudEnvSpecFragment_NodeGroups, 0, len(sdk))
+
+	for _, ng := range model {
+		for _, apiGroup := range sdk {
+			if ng.NodeType.ValueString() == apiGroup.NodeType {
+				orderedNodeGroups = append(orderedNodeGroups, apiGroup)
+				break
+			}
+		}
+	}
+
+	return orderedNodeGroups
+}

--- a/internal/provider/env/hcloud/resource.go
+++ b/internal/provider/env/hcloud/resource.go
@@ -49,12 +49,14 @@ func (r *HCloudEnvResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	tflog.Trace(ctx, "created resource", map[string]interface{}{"name": name})
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.CreateHCloudEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.CreateHCloudEnv.Spec.NodeGroups)
 	data.Id = data.Name
 	data.Locations = common.ListToModel(apiResp.CreateHCloudEnv.Spec.Locations)
 	data.NodeGroups = nodeGroupsToModel(apiResp.CreateHCloudEnv.Spec.NodeGroups)
 	data.SpecRevision = types.Int64Value(apiResp.CreateHCloudEnv.SpecRevision)
 
+	tflog.Trace(ctx, "created resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
@@ -83,8 +85,11 @@ func (r *HCloudEnvResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.HcloudEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.HcloudEnv.Spec.NodeGroups)
 	data.toModel(*apiResp.HcloudEnv)
 	data.Id = data.Name
+
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
@@ -109,11 +114,13 @@ func (r *HCloudEnvResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": name})
+	// Reorder node groups to respect order in the user's configuration
+	apiResp.UpdateHCloudEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.UpdateHCloudEnv.Spec.NodeGroups)
 	data.Locations = common.ListToModel(apiResp.UpdateHCloudEnv.Spec.Locations)
 	data.NodeGroups = nodeGroupsToModel(apiResp.UpdateHCloudEnv.Spec.NodeGroups)
 	data.SpecRevision = types.Int64Value(apiResp.UpdateHCloudEnv.SpecRevision)
 
+	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/env/k8s/model.go
+++ b/internal/provider/env/k8s/model.go
@@ -407,3 +407,18 @@ func maintenanceWindowsToModel(input []*client.K8SEnvSpecFragment_MaintenanceWin
 
 	return maintenanceWindow
 }
+
+func reorderNodeGroups(model []NodeGroupsModel, sdk []*client.K8SEnvSpecFragment_NodeGroups) []*client.K8SEnvSpecFragment_NodeGroups {
+	orderedNodeGroups := make([]*client.K8SEnvSpecFragment_NodeGroups, 0, len(sdk))
+
+	for _, ng := range model {
+		for _, apiGroup := range sdk {
+			if ng.NodeType.ValueString() == apiGroup.NodeType {
+				orderedNodeGroups = append(orderedNodeGroups, apiGroup)
+				break
+			}
+		}
+	}
+
+	return orderedNodeGroups
+}


### PR DESCRIPTION
## Affected Components
* [x] Resources
* [ ] Data Sources
* [ ] Test
* [ ] Docs
* [ ] Tooling
* [ ] Other

## Pre-Requisites
* [x] Terraform and Go code are formatted with `make fmt`
* [x] Documentation updated and re-generated using `make docs`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Re-order node groups after api responses