### PR TITLE
chore: potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sanity-test.yml
+++ b/.github/workflows/sanity-test.yml
@@ -1,4 +1,6 @@
 name: Sanity Tests
+permissions:
+  contents: read
 
 # Triggers terraform sanity tests in the cloud-regression repo and
 # waits for them to finish, mirroring the result (pass/fail/cancelled).


### PR DESCRIPTION
Potential fix for [https://github.com/Altinity/terraform-provider-altinitycloud/security/code-scanning/1](https://github.com/Altinity/terraform-provider-altinitycloud/security/code-scanning/1)

In general, the problem is fixed by explicitly defining a `permissions` block that limits the default `GITHUB_TOKEN` to the least privileges needed by this workflow. If the workflow only needs to read repository contents or metadata, then `permissions: contents: read` (or even `permissions: read-all`) is usually sufficient. More granular write permissions (e.g., `issues: write`) should only be added if the workflow actually needs them.

For this specific workflow, the job is only triggering another workflow in a different repository using a PAT, and there is no indication it needs to write to this repository or modify issues, PRs, etc. The safest change that preserves existing behavior is to add an explicit read-only permission for contents. The cleanest approach is to add a root-level `permissions:` block, right under the `name:` and before `on:`, so it applies to all jobs (there is only one job here). Concretely, in `.github/workflows/sanity-test.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Sanity Tests`). No imports or additional methods are needed since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
