### PR TITLE
feat(azure): Allow specifying the resource group

### DIFF
--- a/internal/provider/common/docs.go
+++ b/internal/provider/common/docs.go
@@ -234,6 +234,7 @@ const AZURE_REGION_DESCRIPTION = `Azure region ([docs](https://azure.microsoft.c
 
 const AZURE_TENANT_ID_DESCRIPTION = "ID of the Azure Active Directory tenant for user identity and access management. **[IMMUTABLE]**"
 const AZURE_SUBSCRIPTION_ID_DESCRIPTION = "ID linking the environment to a specific Azure subscription for resource management. **[IMMUTABLE]**"
+const AZURE_RESOURCE_GROUP_DESCRIPTION = "Name of a pre-existing Azure resource group to deploy into. If not specified, a resource group will be created automatically. **[IMMUTABLE]**"
 const AZURE_PRIVATE_LINK_SERVICE_DESCRIPTION = "Azure Private Link service configuration."
 const AZURE_PRIVATE_LINK_SERVICE_ALIAS_DESCRIPTION = "Private Link Service Alias / DNS Name in prefix.GUID.suffix format."
 const AZURE_PRIVATE_LINK_SERVICE_ALLOWED_SUBSCRIPTIONS_DESCRIPTION = "Lists subscription IDs permitted for Private Link access, securing service connections."

--- a/internal/provider/env/azure/model.go
+++ b/internal/provider/env/azure/model.go
@@ -18,6 +18,7 @@ type AzureEnvResourceModel struct {
 	CIDR                  types.String                    `tfsdk:"cidr"`
 	TenantID              types.String                    `tfsdk:"tenant_id"`
 	SubscriptionID        types.String                    `tfsdk:"subscription_id"`
+	ResourceGroup         types.String                    `tfsdk:"resource_group"`
 	Zones                 types.List                      `tfsdk:"zones"`
 	LoadBalancers         *LoadBalancersModel             `tfsdk:"load_balancers"`
 	LoadBalancingStrategy types.String                    `tfsdk:"load_balancing_strategy"`
@@ -95,6 +96,7 @@ func (e AzureEnvResourceModel) toSDK(ctx context.Context) (client.CreateAzureEnv
 			NodeGroups:            nodeGroups,
 			TenantID:              e.TenantID.ValueString(),
 			SubscriptionID:        e.SubscriptionID.ValueString(),
+			ResourceGroup:         e.ResourceGroup.ValueStringPointer(),
 			Region:                e.Region.ValueString(),
 			Cidr:                  e.CIDR.ValueString(),
 			Zones:                 zones,
@@ -140,6 +142,7 @@ func (model *AzureEnvResourceModel) toModel(env client.GetAzureEnv_AzureEnv) dia
 	model.CIDR = types.StringValue(env.Spec.Cidr)
 	model.SubscriptionID = types.StringValue(env.Spec.SubscriptionID)
 	model.TenantID = types.StringValue(env.Spec.TenantID)
+	model.ResourceGroup = types.StringPointerValue(env.Spec.ResourceGroup)
 	model.LoadBalancingStrategy = types.StringValue(string(env.Spec.LoadBalancingStrategy))
 	model.LoadBalancers = loadBalancersToModel(env.Spec.LoadBalancers)
 

--- a/internal/provider/env/azure/schema.go
+++ b/internal/provider/env/azure/schema.go
@@ -34,6 +34,7 @@ func (r *AzureEnvResource) Schema(ctx context.Context, req resource.SchemaReques
 			"region":                          common.GetRegionAttribute(true, false, false, common.AZURE_REGION_DESCRIPTION),
 			"tenant_id":                       getAzureTenantIDAttribute(true, false, false),
 			"subscription_id":                 getAzureSubscriptionIDAttribute(true, false, false),
+			"resource_group":                  getAzureResourceGroupAttribute(false, true, true),
 			"tags":                            getTagsAttribute(false, true, false),
 			"private_link_service":            getPrivateLinkServiceAttribute(false, true, true),
 			"metrics_endpoint":                common.GetMetricsEndpointAttribute(false, true, false),
@@ -62,6 +63,7 @@ func (d *AzureEnvDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 			"region":                  common.GetRegionAttribute(false, false, true, common.AZURE_REGION_DESCRIPTION),
 			"tenant_id":               getAzureTenantIDAttribute(false, false, true),
 			"subscription_id":         getAzureSubscriptionIDAttribute(false, false, true),
+			"resource_group":          getAzureResourceGroupAttribute(false, false, true),
 			"tags":                    getTagsAttribute(false, false, true),
 			"private_link_service":    getPrivateLinkServiceAttribute(false, false, true),
 			"metrics_endpoint":        common.GetMetricsEndpointAttribute(false, false, true),
@@ -138,6 +140,18 @@ func getAzureSubscriptionIDAttribute(required, optional, computed bool) rschema.
 		MarkdownDescription: common.AZURE_SUBSCRIPTION_ID_DESCRIPTION,
 		PlanModifiers: []planmodifier.String{
 			modifiers.ImmutableString("subscription_id"),
+		},
+	}
+}
+
+func getAzureResourceGroupAttribute(required, optional, computed bool) rschema.StringAttribute {
+	return rschema.StringAttribute{
+		Optional:            optional,
+		Required:            required,
+		Computed:            computed,
+		MarkdownDescription: common.AZURE_RESOURCE_GROUP_DESCRIPTION,
+		PlanModifiers: []planmodifier.String{
+			modifiers.ImmutableString("resource_group"),
 		},
 	}
 }

--- a/internal/sdk/client/schema_azure_env.graphql
+++ b/internal/sdk/client/schema_azure_env.graphql
@@ -94,6 +94,7 @@ fragment AzureEnvSpecFragment on AzureEnvSpec {
   cidr
   tenantID
   subscriptionID
+  resourceGroup
   cloudConnect
   metricsEndpoint {
     enabled


### PR DESCRIPTION
Typically, when deploying resources in Azure, the user is expected to provide a name of a resource group that is [either in existence](https://learn.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-cli#create-a-resource-group) or will be created by the command.

E.g. for AKS:
```
az aks create \
  --resource-group $MY_RESOURCE_GROUP_NAME \
  --name $MY_AKS_CLUSTER_NAME \
  --node-count 1 \
  --generate-ssh-keys \
```

Or for Azure RedHat Openshift:
```
az aro create \
  --resource-group $RESOURCEGROUP \
  --name $CLUSTER \
  --vnet $VIRTUALNETWORK \
  --master-subnet master-subnet \
  --worker-subnet worker-subnet \
  --version <x.y.z>
```

When using our terraform templates, creating a resource group and attaching the service principal to it (reducing the scope of the role binds as a result) I cannot specify for the azure environment to use it. This changes that by allowing for the resource group to be specified.