### PR TITLE
feat: add ValidateConfig for cross-attribute validation

### DIFF
--- a/internal/provider/env/aws/resource.go
+++ b/internal/provider/env/aws/resource.go
@@ -3,7 +3,9 @@ package env
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
@@ -14,6 +16,7 @@ import (
 
 var _ resource.Resource = &AWSEnvResource{}
 var _ resource.ResourceWithImportState = &AWSEnvResource{}
+var _ resource.ResourceWithValidateConfig = &AWSEnvResource{}
 
 func NewAWSEnvResource() resource.Resource {
 	return &AWSEnvResource{}
@@ -236,4 +239,32 @@ func (r *AWSEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		deleteTimeout,
 		common.MFATimeout,
 	)
+}
+
+func (r *AWSEnvResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data AWSEnvResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate that zones match the region prefix (e.g. region "us-east-1" → zones "us-east-1a", "us-east-1b").
+	if !data.Region.IsNull() && !data.Region.IsUnknown() && !data.Zones.IsNull() && !data.Zones.IsUnknown() {
+		region := data.Region.ValueString()
+		var zones []string
+		resp.Diagnostics.Append(data.Zones.ElementsAs(ctx, &zones, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		for i, zone := range zones {
+			if !strings.HasPrefix(zone, region) {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("zones").AtListIndex(i),
+					"Invalid Zone",
+					fmt.Sprintf("Zone %q is not valid for region %q. AWS zones must start with the region name (e.g. %sa, %sb).",
+						zone, region, region, region),
+				)
+			}
+		}
+	}
 }

--- a/internal/provider/env/gcp/resource.go
+++ b/internal/provider/env/gcp/resource.go
@@ -3,7 +3,9 @@ package env
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
@@ -14,6 +16,7 @@ import (
 
 var _ resource.Resource = &GCPEnvResource{}
 var _ resource.ResourceWithImportState = &GCPEnvResource{}
+var _ resource.ResourceWithValidateConfig = &GCPEnvResource{}
 
 func NewGCPEnvResource() resource.Resource {
 	return &GCPEnvResource{}
@@ -236,4 +239,32 @@ func (r *GCPEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		deleteTimeout,
 		common.MFATimeout,
 	)
+}
+
+func (r *GCPEnvResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data GCPEnvResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate that zones match the region prefix (e.g. region "us-central1" → zones "us-central1-a", "us-central1-b").
+	if !data.Region.IsNull() && !data.Region.IsUnknown() && !data.Zones.IsNull() && !data.Zones.IsUnknown() {
+		region := data.Region.ValueString()
+		var zones []string
+		resp.Diagnostics.Append(data.Zones.ElementsAs(ctx, &zones, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		for i, zone := range zones {
+			if !strings.HasPrefix(zone, region) {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("zones").AtListIndex(i),
+					"Invalid Zone",
+					fmt.Sprintf("Zone %q is not valid for region %q. GCP zones must start with the region name (e.g. %s-a, %s-b).",
+						zone, region, region, region),
+				)
+			}
+		}
+	}
 }

--- a/internal/provider/env/k8s/resource.go
+++ b/internal/provider/env/k8s/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
@@ -14,6 +15,7 @@ import (
 
 var _ resource.Resource = &K8SEnvResource{}
 var _ resource.ResourceWithImportState = &K8SEnvResource{}
+var _ resource.ResourceWithValidateConfig = &K8SEnvResource{}
 
 func NewK8SEnvResource() resource.Resource {
 	return &K8SEnvResource{}
@@ -208,4 +210,21 @@ func (r *K8SEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		deleteTimeout,
 		common.MFATimeout,
 	)
+}
+
+func (r *K8SEnvResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data K8SEnvResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate that logs.storage.s3 and logs.storage.gcs are mutually exclusive.
+	if data.Logs != nil && data.Logs.Storage.S3 != nil && data.Logs.Storage.GCS != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("logs").AtName("storage"),
+			"Conflicting Storage Configuration",
+			"Only one of logs.storage.s3 or logs.storage.gcs can be configured, not both.",
+		)
+	}
 }


### PR DESCRIPTION
## Summary
- Implement `ResourceWithValidateConfig` on AWS, GCP and K8S env resources
- AWS/GCP: validate that zones match the region prefix (e.g. region `us-east-1` requires zones like `us-east-1a`)
- K8S: validate that `logs.storage.s3` and `logs.storage.gcs` are mutually exclusive

Errors now surface at `terraform validate` / `terraform plan` instead of failing at the API during apply.

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes  
- [ ] `go test ./...` passes
- [ ] AWS env with mismatched zone/region shows error on validate
- [ ] GCP env with mismatched zone/region shows error on validate
- [ ] K8S env with both s3 and gcs configured shows error on validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)