### PR TITLE
feat: add Slack support message to Client Error diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,58 @@ resource "altinitycloud_env_aws" "example" {
 
 ## Troubleshooting
 
-- **Authentication errors:** Ensure your API token is valid and has proper permissions. Check the `ALTINITYCLOUD_API_TOKEN` environment variable.
-- **Environment provisioning fails:** Use the corresponding status data source to wait for provisioning completion and get detailed error information.
-- **Resource dependencies:** Always use status data sources to ensure proper resource ordering and error detection.
+### Invalid or missing API token
 
-### Need Help?
+```
+Missing Altinity.Cloud API Token
+ALTINITYCLOUD_API_TOKEN environment variable or "api_token" provider attribute required.
+```
 
-If you encounter issues not covered above, please [create an issue](https://github.com/altinity/terraform-provider-altinitycloud/issues/new) with detailed information about your problem.
+Make sure you have set the `ALTINITYCLOUD_API_TOKEN` environment variable or the `api_token` provider attribute. If the token is set but you get an `invalid API token` error, generate a new one from [ACM](https://acm.altinity.cloud/) under "My Account" > "Anywhere API Access".
+
+### Immutable attribute modified
+
+```
+Immutable Attribute
+{attribute_name} is immutable and cannot be modified after creation.
+```
+
+Some attributes like `name`, `region`, and `cidr` cannot be changed after the environment is created. To change them, you need to destroy the environment and create a new one.
+
+### Environment provisioning errors
+
+During provisioning, the environment status may report errors like:
+
+- **`DISCONNECTED`** / **`K8S_DISCONNECTED`** — The environment is not connected to Altinity.Cloud. Verify that the cloud connect setup was completed correctly.
+- **`CLOUD_PROVIDER_ACCESS_DENIED`** — The credentials or permissions provided to Altinity.Cloud are insufficient. Check IAM roles, service accounts, or service principals depending on your cloud provider.
+- **`CLOUD_PROVIDER_QUOTA_EXCEEDED`** — Your cloud provider account has reached a resource quota limit. Request a quota increase from your cloud provider.
+- **`CLOUD_PROVIDER_RESOURCE_NOT_FOUND`** / **`GCP_PROJECT_NOT_FOUND`** — A referenced cloud resource (e.g., project, subscription, account) does not exist. Verify the resource identifiers in your configuration.
+
+These errors are visible in the `altinitycloud_env_*_status` data source and in the [ACM](https://acm.altinity.cloud/) UI.
+
+### MFA timeout during destroy
+
+```
+timeout reached while waiting for MFA to be confirmed.
+Please check your MFA device, confirm deletion and run `terraform destroy` again
+```
+
+If your organization has MFA enabled, environment deletion requires manual approval. After running `terraform destroy`, confirm the deletion on your MFA device within 5 minutes. If the timeout is reached, simply run `terraform destroy` again.
+
+### Destroying an environment
+
+Environment deletion is protected by default and requires specific flags to be set before running `terraform destroy`. Common issues include: the environment being locked (`force_destroy`), having active clusters (`force_destroy_clusters`), or being disconnected (`allow_delete_while_disconnected`).
+
+See the **Deprovision / Destroy** section in each environment resource documentation for detailed instructions.
+
+## Support
+
+If you need help, reach out to us via Slack:
+
+- **Enterprise customers**: Use your organization's dedicated Altinity Slack channel.
+- **Community**: Join the [AltinityDB workspace](https://altinitydbworkspace.slack.com/) and post in the **#terraform** channel.
+
+You can also [create an issue](https://github.com/altinity/terraform-provider-altinitycloud/issues/new) on GitHub.
 
 ## Contributing
 

--- a/internal/provider/common/support.go
+++ b/internal/provider/common/support.go
@@ -1,0 +1,11 @@
+package common
+
+const SupportMessage = `
+
+If you need help, reach out to us via Slack:
+  - Enterprise customers: Use your organization's dedicated Altinity Slack channel.
+  - Community: Join the AltinityDB workspace (https://altinitydbworkspace.slack.com/) and post in the #terraform channel.`
+
+func FormatClientError(detail string) string {
+	return detail + SupportMessage
+}

--- a/internal/provider/common/support.go
+++ b/internal/provider/common/support.go
@@ -1,11 +1,42 @@
 package common
 
-const SupportMessage = `
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// supportMessage is appended to API-related error diagnostics.
+// It uses plain text (not Markdown) because it renders in Terraform CLI output.
+const supportMessage = `
 
 If you need help, reach out to us via Slack:
   - Enterprise customers: Use your organization's dedicated Altinity Slack channel.
   - Community: Join the AltinityDB workspace (https://altinitydbworkspace.slack.com/) and post in the #terraform channel.`
 
-func FormatClientError(detail string) string {
-	return detail + SupportMessage
+// AddClientError appends a "Client Error" diagnostic to diags. The support
+// message is only appended once per diagnostics collection to avoid duplicates
+// when multiple errors are emitted during the same operation.
+func AddClientError(diags *diag.Diagnostics, detail string) {
+	AddSupportError(diags, "Client Error", detail)
+}
+
+// AddSupportError appends an error diagnostic with the given summary and
+// attaches the support contact message to the detail, but only if no other
+// diagnostic in the collection already includes it.
+func AddSupportError(diags *diag.Diagnostics, summary, detail string) {
+	if hasSupportMessage(*diags) {
+		diags.AddError(summary, detail)
+		return
+	}
+	diags.AddError(summary, detail+supportMessage)
+}
+
+func hasSupportMessage(diags diag.Diagnostics) bool {
+	for _, d := range diags {
+		if strings.Contains(d.Detail(), supportMessage) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/provider/common/support_test.go
+++ b/internal/provider/common/support_test.go
@@ -1,0 +1,102 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+func TestAddClientError_AppendsSupportMessage(t *testing.T) {
+	var diags diag.Diagnostics
+
+	AddClientError(&diags, "something failed")
+
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+	if diags[0].Summary() != "Client Error" {
+		t.Errorf("expected summary %q, got %q", "Client Error", diags[0].Summary())
+	}
+	if !strings.Contains(diags[0].Detail(), "something failed") {
+		t.Errorf("detail does not contain original message: %q", diags[0].Detail())
+	}
+	if !strings.Contains(diags[0].Detail(), "Slack") {
+		t.Errorf("detail does not contain support message: %q", diags[0].Detail())
+	}
+}
+
+func TestAddClientError_DeduplicatesSupportMessage(t *testing.T) {
+	var diags diag.Diagnostics
+
+	AddClientError(&diags, "first error")
+	AddClientError(&diags, "second error")
+	AddClientError(&diags, "third error")
+
+	if len(diags) != 3 {
+		t.Fatalf("expected 3 diagnostics, got %d", len(diags))
+	}
+
+	total := 0
+	for _, d := range diags {
+		total += strings.Count(d.Detail(), supportMessage)
+	}
+	if total != 1 {
+		t.Errorf("expected support message to appear exactly once across diagnostics, got %d", total)
+	}
+
+	if !strings.Contains(diags[0].Detail(), supportMessage) {
+		t.Errorf("first diagnostic should carry the support message")
+	}
+	if strings.Contains(diags[1].Detail(), supportMessage) {
+		t.Errorf("second diagnostic should not carry the support message")
+	}
+	if strings.Contains(diags[2].Detail(), supportMessage) {
+		t.Errorf("third diagnostic should not carry the support message")
+	}
+}
+
+func TestAddSupportError_UsesProvidedSummary(t *testing.T) {
+	var diags diag.Diagnostics
+
+	AddSupportError(&diags, "Delete Error", "delete failed")
+
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+	if diags[0].Summary() != "Delete Error" {
+		t.Errorf("expected summary %q, got %q", "Delete Error", diags[0].Summary())
+	}
+	if !strings.Contains(diags[0].Detail(), "Slack") {
+		t.Errorf("detail does not contain support message: %q", diags[0].Detail())
+	}
+}
+
+func TestAddSupportError_DedupAcrossDifferentSummaries(t *testing.T) {
+	var diags diag.Diagnostics
+
+	AddClientError(&diags, "client failure")
+	AddSupportError(&diags, "Delete Error", "delete failure")
+	AddSupportError(&diags, "Status Error", "status failure")
+
+	total := 0
+	for _, d := range diags {
+		total += strings.Count(d.Detail(), supportMessage)
+	}
+	if total != 1 {
+		t.Errorf("expected support message to appear exactly once across all error types, got %d", total)
+	}
+}
+
+func TestAddClientError_EmptyDetail(t *testing.T) {
+	var diags diag.Diagnostics
+
+	AddClientError(&diags, "")
+
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+	if !strings.Contains(diags[0].Detail(), "Slack") {
+		t.Errorf("detail should contain support message even for empty input")
+	}
+}

--- a/internal/provider/env/aws/data_source.go
+++ b/internal/provider/env/aws/data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -60,12 +60,12 @@ func (d *AWSEnvDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	envName := data.Name.ValueString()
 	apiResp, err := d.client.GetAWSEnv(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
 	if apiResp.AWSEnv == nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
 		return
 	}
 

--- a/internal/provider/env/aws/data_source.go
+++ b/internal/provider/env/aws/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -59,12 +60,12 @@ func (d *AWSEnvDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	envName := data.Name.ValueString()
 	apiResp, err := d.client.GetAWSEnv(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
 	if apiResp.AWSEnv == nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Environment %s was not found", envName))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
 		return
 	}
 

--- a/internal/provider/env/aws/resource.go
+++ b/internal/provider/env/aws/resource.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -48,7 +48,7 @@ func (r *AWSEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 	apiResp, err := r.Client.CreateAWSEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to create env %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to create env %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
@@ -98,7 +98,7 @@ func (r *AWSEnvResource) Read(ctx context.Context, req resource.ReadRequest, res
 			tflog.Trace(ctx, "removing resource from state", map[string]interface{}{"name": envName})
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
+			clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
 		}
 		return
 	}
@@ -149,7 +149,7 @@ func (r *AWSEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 	apiResp, err := r.Client.UpdateAWSEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to update env %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to update env %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
@@ -201,7 +201,7 @@ func (r *AWSEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		if notFound {
 			tflog.Trace(ctx, "deleted resource", map[string]interface{}{"name": envName})
 		} else {
-			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, err)))
+			clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, err))
 		}
 		return
 	}
@@ -228,7 +228,7 @@ func (r *AWSEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	})
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(common.FormatDeleteError(envName, err)))
+		clientsupport.AddClientError(&resp.Diagnostics, common.FormatDeleteError(envName, err))
 		return
 	}
 

--- a/internal/provider/env/aws/resource.go
+++ b/internal/provider/env/aws/resource.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -47,7 +48,7 @@ func (r *AWSEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 	apiResp, err := r.Client.CreateAWSEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create env %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to create env %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
@@ -97,7 +98,7 @@ func (r *AWSEnvResource) Read(ctx context.Context, req resource.ReadRequest, res
 			tflog.Trace(ctx, "removing resource from state", map[string]interface{}{"name": envName})
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
+			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
 		}
 		return
 	}
@@ -148,7 +149,7 @@ func (r *AWSEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 	apiResp, err := r.Client.UpdateAWSEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update env %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to update env %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
@@ -200,7 +201,7 @@ func (r *AWSEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		if notFound {
 			tflog.Trace(ctx, "deleted resource", map[string]interface{}{"name": envName})
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status  %s, got error: %s", envName, err))
+			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status  %s, got error: %s", envName, err)))
 		}
 		return
 	}
@@ -208,7 +209,7 @@ func (r *AWSEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	if len(envStatus.AWSEnv.Status.Errors) > 0 {
 		for _, err := range envStatus.AWSEnv.Status.Errors {
 			if (err.Code == "DISCONNECTED" || err.Code == "K8S_DISCONNECTED") && !data.SkipDeprovisionOnDestroy.ValueBool() && !data.AllowDeleteWhileDisconnected.ValueBool() {
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to start env %s, environment is DISCONNECTED.\nCheck environment's `cloudconnect` or use `allow_delete_while_disconnected=true` to continue with the delete operation.", envName))
+				resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to start env %s, environment is DISCONNECTED.\nCheck environment's `cloudconnect` or use `allow_delete_while_disconnected=true` to continue with the delete operation.", envName)))
 				return
 			}
 		}
@@ -221,7 +222,7 @@ func (r *AWSEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	})
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", common.FormatDeleteError(envName, err))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(common.FormatDeleteError(envName, err)))
 		return
 	}
 

--- a/internal/provider/env/azure/data_source.go
+++ b/internal/provider/env/azure/data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -60,12 +60,12 @@ func (d *AzureEnvDataSource) Read(ctx context.Context, req datasource.ReadReques
 	envName := data.Name.ValueString()
 	apiResp, err := d.client.GetAzureEnv(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
 	if apiResp.AzureEnv == nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
 		return
 	}
 

--- a/internal/provider/env/azure/data_source.go
+++ b/internal/provider/env/azure/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -59,12 +60,12 @@ func (d *AzureEnvDataSource) Read(ctx context.Context, req datasource.ReadReques
 	envName := data.Name.ValueString()
 	apiResp, err := d.client.GetAzureEnv(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
 	if apiResp.AzureEnv == nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Environment %s was not found", envName))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
 		return
 	}
 

--- a/internal/provider/env/azure/resource.go
+++ b/internal/provider/env/azure/resource.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -49,7 +49,7 @@ func (r *AzureEnvResource) Create(ctx context.Context, req resource.CreateReques
 	apiResp, err := r.Client.CreateAzureEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name)))
 		return
 	}
 
@@ -95,7 +95,7 @@ func (r *AzureEnvResource) Read(ctx context.Context, req resource.ReadRequest, r
 			tflog.Trace(ctx, "removing resource from state", map[string]interface{}{"name": envName})
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
+			clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
 		}
 		return
 	}
@@ -142,7 +142,7 @@ func (r *AzureEnvResource) Update(ctx context.Context, req resource.UpdateReques
 	apiResp, err := r.Client.UpdateAzureEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name)))
 		return
 	}
 
@@ -189,7 +189,7 @@ func (r *AzureEnvResource) Delete(ctx context.Context, req resource.DeleteReques
 		if notFound {
 			tflog.Trace(ctx, "deleted resource", map[string]interface{}{"name": envName})
 		} else {
-			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, err)))
+			clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, err))
 		}
 		return
 	}
@@ -216,7 +216,7 @@ func (r *AzureEnvResource) Delete(ctx context.Context, req resource.DeleteReques
 	})
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(common.FormatDeleteError(envName, err)))
+		clientsupport.AddClientError(&resp.Diagnostics, common.FormatDeleteError(envName, err))
 		return
 	}
 

--- a/internal/provider/env/azure/resource.go
+++ b/internal/provider/env/azure/resource.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -48,7 +49,7 @@ func (r *AzureEnvResource) Create(ctx context.Context, req resource.CreateReques
 	apiResp, err := r.Client.CreateAzureEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name))))
 		return
 	}
 
@@ -94,7 +95,7 @@ func (r *AzureEnvResource) Read(ctx context.Context, req resource.ReadRequest, r
 			tflog.Trace(ctx, "removing resource from state", map[string]interface{}{"name": envName})
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
+			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
 		}
 		return
 	}
@@ -141,7 +142,7 @@ func (r *AzureEnvResource) Update(ctx context.Context, req resource.UpdateReques
 	apiResp, err := r.Client.UpdateAzureEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name))))
 		return
 	}
 
@@ -188,7 +189,7 @@ func (r *AzureEnvResource) Delete(ctx context.Context, req resource.DeleteReques
 		if notFound {
 			tflog.Trace(ctx, "deleted resource", map[string]interface{}{"name": envName})
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status  %s, got error: %s", envName, err))
+			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status  %s, got error: %s", envName, err)))
 		}
 		return
 	}
@@ -196,7 +197,7 @@ func (r *AzureEnvResource) Delete(ctx context.Context, req resource.DeleteReques
 	if len(envStatus.AzureEnv.Status.Errors) > 0 {
 		for _, err := range envStatus.AzureEnv.Status.Errors {
 			if (err.Code == "DISCONNECTED" || err.Code == "K8S_DISCONNECTED") && !data.SkipDeprovisionOnDestroy.ValueBool() && !data.AllowDeleteWhileDisconnected.ValueBool() {
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to start env %s, environment is DISCONNECTED.\nCheck environment's `cloudconnect` or use `allow_delete_while_disconnected=true` to continue with the delete operation.", envName))
+				resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to start env %s, environment is DISCONNECTED.\nCheck environment's `cloudconnect` or use `allow_delete_while_disconnected=true` to continue with the delete operation.", envName)))
 				return
 			}
 		}
@@ -209,7 +210,7 @@ func (r *AzureEnvResource) Delete(ctx context.Context, req resource.DeleteReques
 	})
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", common.FormatDeleteError(envName, err))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(common.FormatDeleteError(envName, err)))
 		return
 	}
 

--- a/internal/provider/env/common/delete_helpers.go
+++ b/internal/provider/env/common/delete_helpers.go
@@ -3,7 +3,7 @@ package env
 import (
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
@@ -28,7 +28,7 @@ func ValidateDisconnected(envName string, errorCode string, appliedSpecRevision 
 		} else {
 			msg += "Check environment's `cloudconnect` or use `allow_delete_while_disconnected=true` to continue with the delete operation."
 		}
-		diags.AddError("Client Error", support.FormatClientError(msg))
+		clientsupport.AddClientError(&diags, msg)
 	}
 	return diags
 }

--- a/internal/provider/env/common/resource.go
+++ b/internal/provider/env/common/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/auth"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
@@ -126,6 +127,6 @@ func WaitForDeletion(ctx context.Context, resp *resource.DeleteResponse, envName
 
 	_, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError("Delete Error", fmt.Sprintf("Error waiting for env %s to be deleted: %s", envName, err))
+		clientsupport.AddSupportError(&resp.Diagnostics, "Delete Error", fmt.Sprintf("Error waiting for env %s to be deleted: %s", envName, err))
 	}
 }

--- a/internal/provider/env/gcp/data_source.go
+++ b/internal/provider/env/gcp/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -59,12 +60,12 @@ func (d *GCPEnvDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	envName := data.Name.ValueString()
 	apiResp, err := d.client.GetGCPEnv(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
 	if apiResp.GCPEnv == nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Environment %s was not found", envName))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
 		return
 	}
 

--- a/internal/provider/env/gcp/data_source.go
+++ b/internal/provider/env/gcp/data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -60,12 +60,12 @@ func (d *GCPEnvDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	envName := data.Name.ValueString()
 	apiResp, err := d.client.GetGCPEnv(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
 	if apiResp.GCPEnv == nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
 		return
 	}
 

--- a/internal/provider/env/gcp/resource.go
+++ b/internal/provider/env/gcp/resource.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -48,7 +49,7 @@ func (r *GCPEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 	apiResp, err := r.Client.CreateGCPEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name))))
 		return
 	}
 
@@ -94,7 +95,7 @@ func (r *GCPEnvResource) Read(ctx context.Context, req resource.ReadRequest, res
 			tflog.Trace(ctx, "removing resource from state", map[string]interface{}{"name": envName})
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
+			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
 		}
 		return
 	}
@@ -141,7 +142,7 @@ func (r *GCPEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 	apiResp, err := r.Client.UpdateGCPEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name))))
 		return
 	}
 
@@ -188,7 +189,7 @@ func (r *GCPEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		if notFound {
 			tflog.Trace(ctx, "deleted resource", map[string]interface{}{"name": envName})
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status  %s, got error: %s", envName, err))
+			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status  %s, got error: %s", envName, err)))
 		}
 		return
 	}
@@ -196,7 +197,7 @@ func (r *GCPEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	if len(envStatus.GCPEnv.Status.Errors) > 0 {
 		for _, err := range envStatus.GCPEnv.Status.Errors {
 			if (err.Code == "DISCONNECTED" || err.Code == "K8S_DISCONNECTED") && !data.SkipDeprovisionOnDestroy.ValueBool() && !data.AllowDeleteWhileDisconnected.ValueBool() {
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to start env %s, environment is DISCONNECTED.\nCheck environment's `cloudconnect` or use `allow_delete_while_disconnected=true` to continue with the delete operation.", envName))
+				resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to start env %s, environment is DISCONNECTED.\nCheck environment's `cloudconnect` or use `allow_delete_while_disconnected=true` to continue with the delete operation.", envName)))
 				return
 			}
 		}
@@ -209,7 +210,7 @@ func (r *GCPEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	})
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", common.FormatDeleteError(envName, err))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(common.FormatDeleteError(envName, err)))
 		return
 	}
 

--- a/internal/provider/env/gcp/resource.go
+++ b/internal/provider/env/gcp/resource.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -49,7 +49,7 @@ func (r *GCPEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 	apiResp, err := r.Client.CreateGCPEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name)))
 		return
 	}
 
@@ -95,7 +95,7 @@ func (r *GCPEnvResource) Read(ctx context.Context, req resource.ReadRequest, res
 			tflog.Trace(ctx, "removing resource from state", map[string]interface{}{"name": envName})
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
+			clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
 		}
 		return
 	}
@@ -142,7 +142,7 @@ func (r *GCPEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 	apiResp, err := r.Client.UpdateGCPEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name)))
 		return
 	}
 
@@ -189,7 +189,7 @@ func (r *GCPEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		if notFound {
 			tflog.Trace(ctx, "deleted resource", map[string]interface{}{"name": envName})
 		} else {
-			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, err)))
+			clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, err))
 		}
 		return
 	}
@@ -216,7 +216,7 @@ func (r *GCPEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	})
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(common.FormatDeleteError(envName, err)))
+		clientsupport.AddClientError(&resp.Diagnostics, common.FormatDeleteError(envName, err))
 		return
 	}
 

--- a/internal/provider/env/hcloud/data_source.go
+++ b/internal/provider/env/hcloud/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -59,12 +60,12 @@ func (d *HCloudEnvDataSource) Read(ctx context.Context, req datasource.ReadReque
 	envName := data.Name.ValueString()
 	apiResp, err := d.client.GetHCloudEnv(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
 	if apiResp.HcloudEnv == nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Environment %s was not found", envName))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
 		return
 	}
 

--- a/internal/provider/env/hcloud/data_source.go
+++ b/internal/provider/env/hcloud/data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -60,12 +60,12 @@ func (d *HCloudEnvDataSource) Read(ctx context.Context, req datasource.ReadReque
 	envName := data.Name.ValueString()
 	apiResp, err := d.client.GetHCloudEnv(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
 	if apiResp.HcloudEnv == nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
 		return
 	}
 

--- a/internal/provider/env/hcloud/resource.go
+++ b/internal/provider/env/hcloud/resource.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -49,7 +49,7 @@ func (r *HCloudEnvResource) Create(ctx context.Context, req resource.CreateReque
 	apiResp, err := r.Client.CreateHCloudEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name)))
 		return
 	}
 
@@ -91,7 +91,7 @@ func (r *HCloudEnvResource) Read(ctx context.Context, req resource.ReadRequest, 
 			tflog.Trace(ctx, "removing resource from state", map[string]interface{}{"name": envName})
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
+			clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
 		}
 		return
 	}
@@ -134,7 +134,7 @@ func (r *HCloudEnvResource) Update(ctx context.Context, req resource.UpdateReque
 	apiResp, err := r.Client.UpdateHCloudEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name)))
 		return
 	}
 
@@ -177,7 +177,7 @@ func (r *HCloudEnvResource) Delete(ctx context.Context, req resource.DeleteReque
 		if notFound {
 			tflog.Trace(ctx, "deleted resource", map[string]interface{}{"name": envName})
 		} else {
-			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, err)))
+			clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, err))
 		}
 		return
 	}
@@ -204,7 +204,7 @@ func (r *HCloudEnvResource) Delete(ctx context.Context, req resource.DeleteReque
 	})
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(common.FormatDeleteError(envName, err)))
+		clientsupport.AddClientError(&resp.Diagnostics, common.FormatDeleteError(envName, err))
 		return
 	}
 

--- a/internal/provider/env/hcloud/resource.go
+++ b/internal/provider/env/hcloud/resource.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -48,7 +49,7 @@ func (r *HCloudEnvResource) Create(ctx context.Context, req resource.CreateReque
 	apiResp, err := r.Client.CreateHCloudEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name))))
 		return
 	}
 
@@ -90,7 +91,7 @@ func (r *HCloudEnvResource) Read(ctx context.Context, req resource.ReadRequest, 
 			tflog.Trace(ctx, "removing resource from state", map[string]interface{}{"name": envName})
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
+			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
 		}
 		return
 	}
@@ -133,7 +134,7 @@ func (r *HCloudEnvResource) Update(ctx context.Context, req resource.UpdateReque
 	apiResp, err := r.Client.UpdateHCloudEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name))))
 		return
 	}
 
@@ -176,7 +177,7 @@ func (r *HCloudEnvResource) Delete(ctx context.Context, req resource.DeleteReque
 		if notFound {
 			tflog.Trace(ctx, "deleted resource", map[string]interface{}{"name": envName})
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status  %s, got error: %s", envName, err))
+			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status  %s, got error: %s", envName, err)))
 		}
 		return
 	}
@@ -184,7 +185,7 @@ func (r *HCloudEnvResource) Delete(ctx context.Context, req resource.DeleteReque
 	if len(envStatus.HcloudEnv.Status.Errors) > 0 {
 		for _, err := range envStatus.HcloudEnv.Status.Errors {
 			if (err.Code == "DISCONNECTED" || err.Code == "K8S_DISCONNECTED") && !data.SkipDeprovisionOnDestroy.ValueBool() && !data.AllowDeleteWhileDisconnected.ValueBool() {
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to start env %s, environment is DISCONNECTED.\nCheck environment's `cloudconnect` or use `allow_delete_while_disconnected=true` to continue with the delete operation.", envName))
+				resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to start env %s, environment is DISCONNECTED.\nCheck environment's `cloudconnect` or use `allow_delete_while_disconnected=true` to continue with the delete operation.", envName)))
 				return
 			}
 		}
@@ -197,7 +198,7 @@ func (r *HCloudEnvResource) Delete(ctx context.Context, req resource.DeleteReque
 	})
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", common.FormatDeleteError(envName, err))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(common.FormatDeleteError(envName, err)))
 		return
 	}
 

--- a/internal/provider/env/k8s/data_source.go
+++ b/internal/provider/env/k8s/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -59,12 +60,12 @@ func (d *K8SEnvDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	envName := data.Name.ValueString()
 	apiResp, err := d.client.GetK8SEnv(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
 	if apiResp.K8sEnv == nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Environment %s was not found", envName))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
 		return
 	}
 

--- a/internal/provider/env/k8s/data_source.go
+++ b/internal/provider/env/k8s/data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -60,12 +60,12 @@ func (d *K8SEnvDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	envName := data.Name.ValueString()
 	apiResp, err := d.client.GetK8SEnv(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
 	if apiResp.K8sEnv == nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
 		return
 	}
 

--- a/internal/provider/env/k8s/resource.go
+++ b/internal/provider/env/k8s/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -47,7 +48,7 @@ func (r *K8SEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 	apiResp, err := r.Client.CreateK8SEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name))))
 		return
 	}
 
@@ -87,7 +88,7 @@ func (r *K8SEnvResource) Read(ctx context.Context, req resource.ReadRequest, res
 			tflog.Trace(ctx, "removing resource from state", map[string]interface{}{"name": envName})
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
+			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
 		}
 		return
 	}
@@ -125,7 +126,7 @@ func (r *K8SEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 	apiResp, err := r.Client.UpdateK8SEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name))))
 		return
 	}
 
@@ -162,7 +163,7 @@ func (r *K8SEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		if notFound {
 			tflog.Trace(ctx, "deleted resource", map[string]interface{}{"name": envName})
 		} else {
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status  %s, got error: %s", envName, err))
+			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status  %s, got error: %s", envName, err)))
 		}
 		return
 	}
@@ -170,7 +171,7 @@ func (r *K8SEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	if len(envStatus.K8sEnv.Status.Errors) > 0 {
 		for _, err := range envStatus.K8sEnv.Status.Errors {
 			if (err.Code == "DISCONNECTED" || err.Code == "K8S_DISCONNECTED") && !data.SkipDeprovisionOnDestroy.ValueBool() && !data.AllowDeleteWhileDisconnected.ValueBool() {
-				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to start env %s, environment is DISCONNECTED.\nCheck environment's `cloudconnect` or use `allow_delete_while_disconnected=true` to continue with the delete operation.", envName))
+				resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to start env %s, environment is DISCONNECTED.\nCheck environment's `cloudconnect` or use `allow_delete_while_disconnected=true` to continue with the delete operation.", envName)))
 				return
 			}
 		}
@@ -183,7 +184,7 @@ func (r *K8SEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	})
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", common.FormatDeleteError(envName, err))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(common.FormatDeleteError(envName, err)))
 		return
 	}
 

--- a/internal/provider/env/k8s/resource.go
+++ b/internal/provider/env/k8s/resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	common "github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/common"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -48,7 +48,7 @@ func (r *K8SEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 	apiResp, err := r.Client.CreateK8SEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to create env %s, got error: %s", name, client.FormatError(err, name)))
 		return
 	}
 
@@ -88,7 +88,7 @@ func (r *K8SEnvResource) Read(ctx context.Context, req resource.ReadRequest, res
 			tflog.Trace(ctx, "removing resource from state", map[string]interface{}{"name": envName})
 			resp.State.RemoveResource(ctx)
 		} else {
-			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName))))
+			clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env %s, got error: %s", envName, client.FormatError(err, envName)))
 		}
 		return
 	}
@@ -126,7 +126,7 @@ func (r *K8SEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 	apiResp, err := r.Client.UpdateK8SEnv(ctx, sdkEnv)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to update env %s, got error: %s", name, client.FormatError(err, name)))
 		return
 	}
 
@@ -163,7 +163,7 @@ func (r *K8SEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		if notFound {
 			tflog.Trace(ctx, "deleted resource", map[string]interface{}{"name": envName})
 		} else {
-			resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, err)))
+			clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, err))
 		}
 		return
 	}
@@ -190,7 +190,7 @@ func (r *K8SEnvResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	})
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(common.FormatDeleteError(envName, err)))
+		clientsupport.AddClientError(&resp.Diagnostics, common.FormatDeleteError(envName, err))
 		return
 	}
 

--- a/internal/provider/env_certificate/resource.go
+++ b/internal/provider/env_certificate/resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/auth"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
@@ -60,7 +60,7 @@ func (r *CertificateResource) Create(ctx context.Context, req resource.CreateReq
 	tflog.Trace(ctx, "creating resource")
 	crt, key, err := r.auth.GenerateCertificate(ctx, data.EnvironmentName.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable generate certificate, got error: %s", err)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable generate certificate, got error: %s", err))
 		return
 	}
 	data.PEM = types.StringValue(crt + "\n" + key)
@@ -90,7 +90,7 @@ func (r *CertificateResource) Update(ctx context.Context, req resource.UpdateReq
 
 	crt, key, err := r.auth.GenerateCertificate(ctx, data.EnvironmentName.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable generate certificate, got error: %s", err)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable generate certificate, got error: %s", err))
 		return
 	}
 	data.PEM = types.StringValue(crt + "\n" + key)

--- a/internal/provider/env_certificate/resource.go
+++ b/internal/provider/env_certificate/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/auth"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
@@ -59,7 +60,7 @@ func (r *CertificateResource) Create(ctx context.Context, req resource.CreateReq
 	tflog.Trace(ctx, "creating resource")
 	crt, key, err := r.auth.GenerateCertificate(ctx, data.EnvironmentName.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable generate certificate, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable generate certificate, got error: %s", err)))
 		return
 	}
 	data.PEM = types.StringValue(crt + "\n" + key)
@@ -94,7 +95,7 @@ func (r *CertificateResource) Update(ctx context.Context, req resource.UpdateReq
 
 	crt, key, err := r.auth.GenerateCertificate(ctx, data.EnvironmentName.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable generate certificate, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable generate certificate, got error: %s", err)))
 		return
 	}
 	data.PEM = types.StringValue(crt + "\n" + key)

--- a/internal/provider/env_secret/resource.go
+++ b/internal/provider/env_secret/resource.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/crypto"
@@ -61,7 +61,7 @@ func (r *SecretResource) Create(ctx context.Context, req resource.CreateRequest,
 	secretValue, err := r.crypto.Encrypt(data.PEM.ValueString(), data.Value.ValueString())
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable encrypt, got error: %s", err)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable encrypt, got error: %s", err))
 		return
 	}
 	data.SecretValue = types.StringValue(secretValue)
@@ -91,7 +91,7 @@ func (r *SecretResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	secretValue, err := r.crypto.Encrypt(data.PEM.ValueString(), data.Value.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable generate secret, got error: %s", err)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable generate secret, got error: %s", err))
 		return
 	}
 	data.SecretValue = types.StringValue(secretValue)

--- a/internal/provider/env_secret/resource.go
+++ b/internal/provider/env_secret/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/crypto"
@@ -60,7 +61,7 @@ func (r *SecretResource) Create(ctx context.Context, req resource.CreateRequest,
 	secretValue, err := r.crypto.Encrypt(data.PEM.ValueString(), data.Value.ValueString())
 
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable encrypt, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable encrypt, got error: %s", err)))
 		return
 	}
 	data.SecretValue = types.StringValue(secretValue)
@@ -95,7 +96,7 @@ func (r *SecretResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	secretValue, err := r.crypto.Encrypt(data.PEM.ValueString(), data.Value.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable generate secret, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable generate secret, got error: %s", err)))
 		return
 	}
 	data.SecretValue = types.StringValue(secretValue)

--- a/internal/provider/env_status/aws/data_source.go
+++ b/internal/provider/env_status/aws/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env_status/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -38,12 +39,12 @@ func (d *AWSEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 	envName := data.Name.ValueString()
 	apiResp, err := d.Client.GetAWSEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
 	if apiResp.AWSEnv == nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Environment %s was not found", envName))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
 		return
 	}
 
@@ -91,7 +92,7 @@ func (d *AWSEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 	// Re-fetch to populate the model with latest data
 	apiResp, err = d.Client.GetAWSEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 

--- a/internal/provider/env_status/aws/data_source.go
+++ b/internal/provider/env_status/aws/data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env_status/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -39,12 +39,12 @@ func (d *AWSEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 	envName := data.Name.ValueString()
 	apiResp, err := d.Client.GetAWSEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
 	if apiResp.AWSEnv == nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
 		return
 	}
 
@@ -92,7 +92,7 @@ func (d *AWSEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 	// Re-fetch to populate the model with latest data
 	apiResp, err = d.Client.GetAWSEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 

--- a/internal/provider/env_status/azure/data_source.go
+++ b/internal/provider/env_status/azure/data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env_status/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -39,12 +39,12 @@ func (d *AzureEnvStatusDataSource) Read(ctx context.Context, req datasource.Read
 	envName := data.Name.ValueString()
 	apiResp, err := d.Client.GetAzureEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
 	if apiResp.AzureEnv == nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
 		return
 	}
 
@@ -91,7 +91,7 @@ func (d *AzureEnvStatusDataSource) Read(ctx context.Context, req datasource.Read
 
 	apiResp, err = d.Client.GetAzureEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 

--- a/internal/provider/env_status/azure/data_source.go
+++ b/internal/provider/env_status/azure/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env_status/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -38,12 +39,12 @@ func (d *AzureEnvStatusDataSource) Read(ctx context.Context, req datasource.Read
 	envName := data.Name.ValueString()
 	apiResp, err := d.Client.GetAzureEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
 	if apiResp.AzureEnv == nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Environment %s was not found", envName))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
 		return
 	}
 
@@ -90,7 +91,7 @@ func (d *AzureEnvStatusDataSource) Read(ctx context.Context, req datasource.Read
 
 	apiResp, err = d.Client.GetAzureEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 

--- a/internal/provider/env_status/common/data_source.go
+++ b/internal/provider/env_status/common/data_source.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -139,7 +140,7 @@ func WaitForSpecRevision(ctx context.Context, envName string, targetRevision int
 
 	_, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		diags.AddError("Status Error", fmt.Sprintf("Error waiting for env status %s: %s", envName, err))
+		clientsupport.AddSupportError(diags, "Status Error", fmt.Sprintf("Error waiting for env status %s: %s", envName, err))
 		return false
 	}
 	return true

--- a/internal/provider/env_status/gcp/data_source.go
+++ b/internal/provider/env_status/gcp/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env_status/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -38,12 +39,12 @@ func (d *GCPEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 	envName := data.Name.ValueString()
 	apiResp, err := d.Client.GetGCPEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
 	if apiResp.GCPEnv == nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Environment %s was not found", envName))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
 		return
 	}
 
@@ -90,7 +91,7 @@ func (d *GCPEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 	apiResp, err = d.Client.GetGCPEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 

--- a/internal/provider/env_status/gcp/data_source.go
+++ b/internal/provider/env_status/gcp/data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env_status/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -39,12 +39,12 @@ func (d *GCPEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 	envName := data.Name.ValueString()
 	apiResp, err := d.Client.GetGCPEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
 	if apiResp.GCPEnv == nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
 		return
 	}
 
@@ -91,7 +91,7 @@ func (d *GCPEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 	apiResp, err = d.Client.GetGCPEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 

--- a/internal/provider/env_status/hcloud/data_source.go
+++ b/internal/provider/env_status/hcloud/data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env_status/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -39,12 +39,12 @@ func (d *HCloudEnvStatusDataSource) Read(ctx context.Context, req datasource.Rea
 	envName := data.Name.ValueString()
 	apiResp, err := d.Client.GetHCloudEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
 	if apiResp.HcloudEnv == nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
 		return
 	}
 
@@ -91,7 +91,7 @@ func (d *HCloudEnvStatusDataSource) Read(ctx context.Context, req datasource.Rea
 
 	apiResp, err = d.Client.GetHCloudEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 

--- a/internal/provider/env_status/hcloud/data_source.go
+++ b/internal/provider/env_status/hcloud/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env_status/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -38,12 +39,12 @@ func (d *HCloudEnvStatusDataSource) Read(ctx context.Context, req datasource.Rea
 	envName := data.Name.ValueString()
 	apiResp, err := d.Client.GetHCloudEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
 	if apiResp.HcloudEnv == nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Environment %s was not found", envName))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
 		return
 	}
 
@@ -90,7 +91,7 @@ func (d *HCloudEnvStatusDataSource) Read(ctx context.Context, req datasource.Rea
 
 	apiResp, err = d.Client.GetHCloudEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 

--- a/internal/provider/env_status/k8s/data_source.go
+++ b/internal/provider/env_status/k8s/data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
+	clientsupport "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env_status/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -39,12 +39,12 @@ func (d *K8SEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 	envName := data.Name.ValueString()
 	apiResp, err := d.Client.GetK8SEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 
 	if apiResp.K8sEnv == nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
 		return
 	}
 
@@ -91,7 +91,7 @@ func (d *K8SEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 	apiResp, err = d.Client.GetK8SEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
 		return
 	}
 

--- a/internal/provider/env_status/k8s/data_source.go
+++ b/internal/provider/env_status/k8s/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	support "github.com/altinity/terraform-provider-altinitycloud/internal/provider/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env_status/common"
 	"github.com/altinity/terraform-provider-altinitycloud/internal/sdk/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -38,12 +39,12 @@ func (d *K8SEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 	envName := data.Name.ValueString()
 	apiResp, err := d.Client.GetK8SEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 
 	if apiResp.K8sEnv == nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Environment %s was not found", envName))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Environment %s was not found", envName)))
 		return
 	}
 
@@ -90,7 +91,7 @@ func (d *K8SEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 	apiResp, err = d.Client.GetK8SEnvStatus(ctx, envName)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName)))
+		resp.Diagnostics.AddError("Client Error", support.FormatClientError(fmt.Sprintf("Unable to read env status %s, got error: %s", envName, client.FormatError(err, envName))))
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Add `FormatClientError` helper in `internal/provider/common/support.go` that appends Slack contact info to error messages
- Wrap all 59 `AddError("Client Error", ...)` call sites across 17 files with `support.FormatClientError(...)`
- Applies to: env resources (CRUD), env data sources, env_status data sources, env_secret, env_certificate
- Does NOT apply to: validation errors ("Env Locked", "Immutable Attribute"), configuration errors, or internal errors

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/provider/...` passes
- [x] `golangci-lint` passes
- [x] Verified no `AddError("Client Error"` remains unwrapped via grep