### PR TITLE
fix: add default object plan modifier to metrics_endpoint

### DIFF
--- a/internal/provider/common/attributes.go
+++ b/internal/provider/common/attributes.go
@@ -299,6 +299,12 @@ func GetMetricsEndpointAttribute(required, optional, computed bool) rschema.Sing
 		Required:            required,
 		Computed:            computed,
 		MarkdownDescription: METRICS_ENDPOINT_DESCRIPTION,
+		PlanModifiers: []planmodifier.Object{
+			modifiers.DefaultObject(map[string]attr.Value{
+				"enabled":          types.BoolValue(false),
+				"source_ip_ranges": types.ListNull(types.StringType),
+			}),
+		},
 		Attributes: map[string]rschema.Attribute{
 			"enabled": rschema.BoolAttribute{
 				Optional:            true,

--- a/internal/provider/env/aws/schema.go
+++ b/internal/provider/env/aws/schema.go
@@ -49,7 +49,7 @@ func (r *AWSEnvResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"external_buckets":                getExternalBucketsAttribute(false, true, false),
 			"backups":                         getBackupStorageAttribute(false, true, false),
 			"iceberg":                         getIcebergAttribute(false, true, false),
-			"metrics_endpoint":                common.GetMetricsEndpointAttribute(false, true, false),
+			"metrics_endpoint":                common.GetMetricsEndpointAttribute(false, true, true),
 			"datadog":                         common.GetDatadogAttribute(false, true, false),
 			"eks_logging":                     getEksLoggingAttribute(false, true, true),
 

--- a/internal/provider/env/azure/schema.go
+++ b/internal/provider/env/azure/schema.go
@@ -38,7 +38,7 @@ func (r *AzureEnvResource) Schema(ctx context.Context, req resource.SchemaReques
 			"subscription_id":                 getAzureSubscriptionIDAttribute(true, false, false),
 			"tags":                            getTagsAttribute(false, true, false),
 			"private_link_service":            getPrivateLinkServiceAttribute(false, true, true),
-			"metrics_endpoint":                common.GetMetricsEndpointAttribute(false, true, false),
+			"metrics_endpoint":                common.GetMetricsEndpointAttribute(false, true, true),
 			"datadog":                         common.GetDatadogAttribute(false, true, false),
 			"spec_revision":                   common.SpecRevisionAttribute,
 			"force_destroy":                   common.GetForceDestroyAttribute(false, true, true),

--- a/internal/provider/env/gcp/schema.go
+++ b/internal/provider/env/gcp/schema.go
@@ -38,7 +38,7 @@ func (r *GCPEnvResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"peering_connections":       getPeeringConnectionsAttribute(false, true, false),
 			"private_service_consumers": getPrivateServiceConsumersAttribute(false, true, false),
 			"labels":                    getLabelsAttribute(false, true, false),
-			"metrics_endpoint":          common.GetMetricsEndpointAttribute(false, true, false),
+			"metrics_endpoint":          common.GetMetricsEndpointAttribute(false, true, true),
 			"datadog":                   common.GetDatadogAttribute(false, true, false),
 			"spec_revision":             common.SpecRevisionAttribute,
 

--- a/internal/provider/env/hcloud/schema.go
+++ b/internal/provider/env/hcloud/schema.go
@@ -39,7 +39,7 @@ func (r *HCloudEnvResource) Schema(ctx context.Context, req resource.SchemaReque
 			"node_groups":                     getNodeGroupsAttribute(true, false, false),
 			"network_zone":                    common.GetRegionAttribute(true, false, false, common.HCLOUD_NETWORK_ZONE_DESCRIPTION),
 			"wireguard_peers":                 getWireguardPeersAttribute(false, true, false),
-			"metrics_endpoint":                common.GetMetricsEndpointAttribute(false, true, false),
+			"metrics_endpoint":                common.GetMetricsEndpointAttribute(false, true, true),
 			"datadog":                         common.GetDatadogAttribute(false, true, false),
 			"spec_revision":                   common.SpecRevisionAttribute,
 			"force_destroy":                   common.GetForceDestroyAttribute(false, true, true),


### PR DESCRIPTION
## Context

PR #240 reverted `metrics_endpoint` to Optional to stop a crash on env create. That works, but it reintroduces the state drift that `Computed` was added (2e9ffb6) to fix.

## Crash root cause

A Computed `SingleNestedAttribute` plans an **unknown** value when omitted from config. The model uses a plain struct pointer (`*AWSEnvMetricsEndpointModel`) that can't hold unknown → crash:

```
Value Conversion Error: Received unknown value, however the target type
cannot handle unknown values. Target Type: *env.AWSEnvMetricsEndpointModel
```

## Fix

Match the existing `load_balancers` pattern: keep Optional+Computed (so the API-returned value never drifts) and add a `DefaultObject` plan modifier so an omitted block plans a **known default** (`{enabled=false, source_ip_ranges=null}`) instead of unknown.

Plan modifiers can only set planned values on Computed attributes — so Computed must stay, not be reverted. This supersedes the revert in #240.

Applies to aws/azure/gcp/hcloud via the shared `common.GetMetricsEndpointAttribute`.