### PR TITLE
fix: mark spec_revision unknown on update to avoid inconsistent result

### DIFF
--- a/internal/provider/env/aws/modify_plan_test.go
+++ b/internal/provider/env/aws/modify_plan_test.go
@@ -1,0 +1,11 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/testutil"
+)
+
+func TestAWSModifyPlanSpecRevision(t *testing.T) {
+	testutil.AssertModifyPlanSpecRevision(t, &AWSEnvResource{})
+}

--- a/internal/provider/env/azure/modify_plan_test.go
+++ b/internal/provider/env/azure/modify_plan_test.go
@@ -1,0 +1,11 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/testutil"
+)
+
+func TestAzureModifyPlanSpecRevision(t *testing.T) {
+	testutil.AssertModifyPlanSpecRevision(t, &AzureEnvResource{})
+}

--- a/internal/provider/env/common/resource.go
+++ b/internal/provider/env/common/resource.go
@@ -75,6 +75,12 @@ func (r *EnvResourceBase) ModifyPlan(ctx context.Context, req resource.ModifyPla
 		if skipDeprovision.ValueBool() {
 			resp.Diagnostics.AddAttributeWarning(path.Root("skip_deprovision_on_destroy"), "Skip Deprovision on Destroy", "This resource is using the 'skip_deprovision_on_destroy'.\nUse this with precaution as it will delete the environment without deleting any of your cloud resources.")
 		}
+		return
+	}
+
+	// spec_revision is server-reassigned each update; unknown-on-change so the plan doesn't pin the stale value.
+	if !req.State.Raw.IsNull() && !req.Plan.Raw.Equal(req.State.Raw) {
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("spec_revision"), types.Int64Unknown())...)
 	}
 }
 

--- a/internal/provider/env/gcp/modify_plan_test.go
+++ b/internal/provider/env/gcp/modify_plan_test.go
@@ -1,0 +1,11 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/testutil"
+)
+
+func TestGCPModifyPlanSpecRevision(t *testing.T) {
+	testutil.AssertModifyPlanSpecRevision(t, &GCPEnvResource{})
+}

--- a/internal/provider/env/hcloud/modify_plan_test.go
+++ b/internal/provider/env/hcloud/modify_plan_test.go
@@ -1,0 +1,11 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/testutil"
+)
+
+func TestHCloudModifyPlanSpecRevision(t *testing.T) {
+	testutil.AssertModifyPlanSpecRevision(t, &HCloudEnvResource{})
+}

--- a/internal/provider/env/k8s/modify_plan_test.go
+++ b/internal/provider/env/k8s/modify_plan_test.go
@@ -1,0 +1,11 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/env/testutil"
+)
+
+func TestK8SModifyPlanSpecRevision(t *testing.T) {
+	testutil.AssertModifyPlanSpecRevision(t, &K8SEnvResource{})
+}

--- a/internal/provider/env/testutil/modify_plan.go
+++ b/internal/provider/env/testutil/modify_plan.go
@@ -1,0 +1,76 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type SpecRevResource interface {
+	Schema(context.Context, resource.SchemaRequest, *resource.SchemaResponse)
+	ModifyPlan(context.Context, resource.ModifyPlanRequest, *resource.ModifyPlanResponse)
+}
+
+func AssertModifyPlanSpecRevision(t *testing.T, r SpecRevResource) {
+	t.Helper()
+	ctx := context.Background()
+
+	sresp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, sresp)
+	schema := sresp.Schema
+
+	objType, ok := schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema type is not a tftypes.Object")
+	}
+
+	build := func(customDomain string) tftypes.Value {
+		vals := map[string]tftypes.Value{}
+		for n, at := range objType.AttributeTypes {
+			switch n {
+			case "name", "id":
+				vals[n] = tftypes.NewValue(at, "env")
+			case "spec_revision":
+				vals[n] = tftypes.NewValue(at, int64(100))
+			case "custom_domain":
+				vals[n] = tftypes.NewValue(at, customDomain)
+			default:
+				vals[n] = tftypes.NewValue(at, nil)
+			}
+		}
+		return tftypes.NewValue(objType, vals)
+	}
+
+	run := func(state, plan tftypes.Value) types.Int64 {
+		resp := &resource.ModifyPlanResponse{Plan: tfsdk.Plan{Raw: plan, Schema: schema}}
+		r.ModifyPlan(ctx, resource.ModifyPlanRequest{
+			State: tfsdk.State{Raw: state, Schema: schema},
+			Plan:  tfsdk.Plan{Raw: plan, Schema: schema},
+		}, resp)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("ModifyPlan errored: %v", resp.Diagnostics.Errors())
+		}
+		var got types.Int64
+		if d := resp.Plan.GetAttribute(ctx, path.Root("spec_revision"), &got); d.HasError() {
+			t.Fatalf("get spec_revision: %v", d.Errors())
+		}
+		return got
+	}
+
+	t.Run("update with change marks spec_revision unknown", func(t *testing.T) {
+		if got := run(build("old.example.com"), build("new.example.com")); !got.IsUnknown() {
+			t.Fatalf("expected spec_revision unknown on update, got %v", got)
+		}
+	})
+
+	t.Run("no-op plan keeps spec_revision known", func(t *testing.T) {
+		if got := run(build("same.example.com"), build("same.example.com")); got.IsUnknown() || got.ValueInt64() != 100 {
+			t.Fatalf("expected spec_revision to stay 100 on no-op, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
`spec_revision` is reassigned by the API on every update, but as a plain `Computed` attribute it was carried forward in the plan as the stale state value. The apply then returned the new server revision, failing with `Provider produced inconsistent result after apply: .spec_revision`.

In the shared env `ModifyPlan`, mark `spec_revision` unknown when the plan differs from state, leaving no-op plans untouched to avoid churn. Applies to all env resources (`aws`, `azure`, `gcp`, `hcloud`, `k8s`) via `EnvResourceBase`.

Covered by a regression test asserting unknown-on-change and known-on-no-op.