### PR TITLE
test: e2e lifecycle tests against dev control plane

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,28 @@ jobs:
         with:
           version: latest
 
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
+      - run: go mod download
+      # Create/update + drift lifecycle against the dev control plane
+      # (https://anywhere.dev.altinity.cloud) using dummy-prefixed envs. Delete
+      # is skipped (dev requires MFA). Skips entirely when the token secret is
+      # unavailable (e.g. fork PRs).
+      - name: Run e2e tests
+        run: make test-e2e
+        env:
+          ALTINITYCLOUD_API_TOKEN: ${{ secrets.ALTINITYCLOUD_DEV_API_TOKEN }}
+
   generate:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fix perpetual drift (`inconsistent result after apply`) caused by the API returning list fields in a different order than configured; provider now preserves user-defined ordering for node groups, maintenance windows, endpoints, peering connections, tags/labels, external buckets, wireguard peers, and Iceberg catalogs/watches across all environments [#244](https://github.com/Altinity/terraform-provider-altinitycloud/pull/244).
+- Fix k8s node groups with the same `node_type` but different names being matched by type instead of name, corrupting selectors and tolerations after apply [#244](https://github.com/Altinity/terraform-provider-altinitycloud/pull/244).
+- Fix not-found and conflict detection (e.g. a deleted resource not detected as gone on refresh) when a GraphQL error path contains a list index [#244](https://github.com/Altinity/terraform-provider-altinitycloud/pull/244).
+- Fix provider panic in env status data sources when the environment is deleted during the status poll [#244](https://github.com/Altinity/terraform-provider-altinitycloud/pull/244).
+- Fix `nat` exposed as a writable attribute in the AWS env status data source; it is read-only [#244](https://github.com/Altinity/terraform-provider-altinitycloud/pull/244).
+- Check diagnostics before persisting state in env Create/Update so a failed response conversion no longer saves partial state [#244](https://github.com/Altinity/terraform-provider-altinitycloud/pull/244).
+
+### Changed
+- GraphQL client retry logic now skips non-idempotent mutations, replays the request body on retry (previously retried with an empty body), and classifies retryable errors by HTTP status / transport error instead of response body substring matching [#244](https://github.com/Altinity/terraform-provider-altinitycloud/pull/244).
+
 ## [0.7.2](https://github.com/Altinity/terraform-provider-altinitycloud/compare/v0.7.1...v0.7.2)
 ### Fixed
 - Fix `inconsistent result after apply` on `spec_revision` during env updates [#243](https://github.com/Altinity/terraform-provider-altinitycloud/pull/243).

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ install-hooks:
 test:
 	go test -v -cover ./...
 
+.PHONY: test-e2e
+test-e2e:
+	go test -tags e2e -run 'TestE2E' ./... -v $(TESTARGS) -timeout 10m
+
 .PHONY: help
 help:
 	@echo "Available commands:"
@@ -128,6 +132,7 @@ help:
 	@echo "sdk               - Re-sync the SDK client and models. This pulls the latest GraphQL schema and regenerates the client code."
 	@echo "sync              - Fetch and update the current version in the 'example' directory. This syncs the version used in examples with the latest git tag."
 	@echo "test              - Run Go unit tests with coverage. This runs all unit tests in the project and provides coverage information."
+	@echo "test-e2e          - Run e2e lifecycle tests against the dev control plane using dummy-prefixed envs. Skips without ALTINITYCLOUD_API_TOKEN."
 	@echo "testacc           - Run acceptance tests. These are integration tests that use the Terraform binary to test real infrastructure."
 	@echo "tool              - Run Go tools. This is a placeholder for any Go-based tools you might want to run as part of the build."
 

--- a/docs/data-sources/env_aws.md
+++ b/docs/data-sources/env_aws.md
@@ -25,10 +25,6 @@ Bring Your Own Cloud (BYOC) AWS environment data source.
 		Examples:
 		- "acme-staging" (where "acme" is your account name)
 
-### Optional
-
-- `nat` (Boolean) Enable AWS NAT Gateway. **[IMMUTABLE]**
-
 ### Read-Only
 
 - `allow_delete_while_disconnected` (Boolean) Set to `true` to allow deletion of the environment while it is disconnected from the cloud connect. If the the environment is not connected during the deletion process you will end up in a delete timeout (default `false`).
@@ -69,6 +65,7 @@ Bring Your Own Cloud (BYOC) AWS environment data source.
 		- "ZONE_BEST_EFFORT": keep traffic within same zone
 - `maintenance_windows` (Attributes List) List of maintenance windows during which automatic maintenance is permitted. By default updates are applied as soon as they are available. (see [below for nested schema](#nestedatt--maintenance_windows))
 - `metrics_endpoint` (Attributes) Metrics endpoint configuration. (see [below for nested schema](#nestedatt--metrics_endpoint))
+- `nat` (Boolean) Enable AWS NAT Gateway. **[IMMUTABLE]**
 - `node_groups` (Attributes List) List of node groups. At least one required. (see [below for nested schema](#nestedatt--node_groups))
 - `peering_connections` (Attributes List) AWS environment VPC peering configuration. (see [below for nested schema](#nestedatt--peering_connections))
 - `permissions_boundary_policy_arn` (String) Policy ARN that sets the maximum permissions for the IAM roles created by the environment. **[IMMUTABLE]**

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
+	github.com/hashicorp/terraform-exec v0.25.1
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
@@ -56,7 +57,6 @@ require (
 	github.com/hashicorp/hc-install v0.9.5 // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
-	github.com/hashicorp/terraform-exec v0.25.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/stretchr/testify v1.11.1
+	github.com/vektah/gqlparser/v2 v2.5.26
 )
 
 require (
@@ -79,7 +80,6 @@ require (
 	github.com/sosodev/duration v1.3.1 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/urfave/cli/v2 v2.27.6 // indirect
-	github.com/vektah/gqlparser/v2 v2.5.26 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/internal/provider/common/attributes.go
+++ b/internal/provider/common/attributes.go
@@ -242,19 +242,26 @@ func GetAllowDeleteWhileDisconnectedAttribute(required, optional, computed bool)
 }
 
 func GetReservationsAttribute(required, optional, computed bool) rschema.SetAttribute {
+	// The default only takes effect on an Optional+Computed attribute (config may
+	// be null); on a Required attribute it can never fire, so skip it.
+	var planModifiers []planmodifier.Set
+	if computed {
+		planModifiers = []planmodifier.Set{
+			modifiers.DefaultSet(types.StringType, []attr.Value{
+				types.StringValue(string(client.NodeReservationClickhouse)),
+				types.StringValue(string(client.NodeReservationSystem)),
+				types.StringValue(string(client.NodeReservationZookeeper)),
+			}),
+		}
+	}
+
 	return rschema.SetAttribute{
 		ElementType:         types.StringType,
 		Required:            required,
 		Optional:            optional,
 		Computed:            computed,
 		MarkdownDescription: NODE_GROUP_RESERVATIONS_DESCRIPTION,
-		PlanModifiers: []planmodifier.Set{
-			modifiers.DefaultSet(types.StringType, []attr.Value{
-				types.StringValue(string(client.NodeReservationClickhouse)),
-				types.StringValue(string(client.NodeReservationSystem)),
-				types.StringValue(string(client.NodeReservationZookeeper)),
-			}),
-		},
+		PlanModifiers:       planModifiers,
 		Validators: []validator.Set{
 			setvalidator.SizeAtLeast(1),
 			setvalidator.ValueStringsAre(

--- a/internal/provider/env/aws/e2e_test.go
+++ b/internal/provider/env/aws/e2e_test.go
@@ -59,7 +59,7 @@ resource "%s" "dummy" {
 
   node_groups = [
     {
-      zones             = ["us-east-1a"]
+      zones             = ["us-east-1a", "us-east-1b"]
       node_type         = "t4g.large"
       capacity_per_zone = %d
       reservations      = ["SYSTEM", "ZOOKEEPER"]

--- a/internal/provider/env/aws/e2e_test.go
+++ b/internal/provider/env/aws/e2e_test.go
@@ -14,6 +14,9 @@ import (
 // plane (https://anywhere.dev.altinity.cloud) using a dummy-prefixed env, and
 // asserts there is no drift after each apply (a non-empty plan = drift).
 //
+// The config exercises every settable field of the AWS env resource so the
+// drift check validates the full spec round-trip (toSDK -> API -> toModel).
+//
 // Teardown is intentionally skipped: deleting an env on dev requires MFA
 // confirmation, which CI cannot provide. Dummy-prefixed envs are cleaned up out
 // of band.
@@ -24,7 +27,7 @@ func TestE2EAltinityCloudEnvAWS(t *testing.T) {
 
 	envName := "dummy-e2e-aws-" + test.GenerateRandomResourceName()
 
-	// 1. Create.
+	// 1. Create with the full field set.
 	test.WriteE2EConfig(t, workdir, awsE2EConfig(envName, 1))
 	if err := tf.Apply(ctx); err != nil {
 		t.Fatalf("create apply failed: %s", err)
@@ -51,6 +54,15 @@ func TestE2EAltinityCloudEnvAWS(t *testing.T) {
 	t.Logf("e2e create+update+drift OK for %s (delete skipped: dev requires MFA)", envName)
 }
 
+// awsE2EConfig returns an AWS env resource that sets every settable attribute.
+// capacity drives the mutable change exercised by the update step.
+//
+// Intentionally omitted (require real infrastructure the dev sandbox rejects):
+//   - resource_prefix: server-assigned; setting it requires a sandbox-derived
+//     prefix tied to the env name.
+//   - permissions_boundary_policy_arn: requires resource_prefix + a real policy.
+//   - datadog: enabling it requires an encrypted API key (enc_api_key).
+//   - custom_domain: superseded here by custom_domains.
 func awsE2EConfig(envName string, capacity int) string {
 	return fmt.Sprintf(`
 resource "%s" "dummy" {
@@ -60,12 +72,97 @@ resource "%s" "dummy" {
   aws_account_id = "123456789012"
   zones          = ["us-east-1a", "us-east-1b"]
 
-  node_groups = [{
-    zones             = ["us-east-1a"]
-    node_type         = "t4g.large"
-    capacity_per_zone = %d
-    reservations      = ["SYSTEM", "CLICKHOUSE", "ZOOKEEPER"]
+  custom_domains          = ["e2e.example.com"]
+  load_balancing_strategy = "ROUND_ROBIN"
+  nat                     = true
+  cloud_connect           = true
+  eks_logging             = true
+
+  load_balancers = {
+    public = {
+      enabled          = true
+      source_ip_ranges = ["0.0.0.0/0"]
+      cross_zone       = true
+    }
+    internal = {
+      enabled                             = true
+      source_ip_ranges                    = ["10.0.0.0/8"]
+      cross_zone                          = true
+      endpoint_service_allowed_principals = ["arn:aws:iam::123456789012:root"]
+      endpoint_service_supported_regions  = ["us-east-1"]
+    }
+  }
+
+  node_groups = [
+    {
+      zones             = ["us-east-1a"]
+      node_type         = "t4g.large"
+      capacity_per_zone = %d
+      reservations      = ["SYSTEM", "ZOOKEEPER"]
+    },
+    {
+      zones             = ["us-east-1a", "us-east-1b"]
+      node_type         = "m6i.large"
+      capacity_per_zone = 2
+      reservations      = ["CLICKHOUSE"]
+    },
+  ]
+
+  maintenance_windows = [{
+    name            = "weekly"
+    enabled         = true
+    hour            = 2
+    length_in_hours = 4
+    days            = ["MONDAY", "TUESDAY"]
   }]
+
+  peering_connections = [{
+    aws_account_id = "123456789012"
+    vpc_id         = "vpc-12345678"
+    vpc_region     = "us-east-1"
+  }]
+
+  endpoints = [{
+    service_name = "com.amazonaws.vpce.us-east-1.vpce-svc-12345678"
+    alias        = "b-1.dummycluster.a1b2c3.c2.kafka.us-east-1.amazonaws.com"
+    private_dns  = true
+  }]
+
+  tags = [{
+    key   = "team"
+    value = "platform"
+  }]
+
+  external_buckets = [{
+    name = "my-external-bucket"
+  }]
+
+  backups = {
+    custom_bucket = {
+      name     = "my-backup-bucket"
+      region   = "us-east-1"
+      role_arn = "arn:aws:iam::123456789012:role/backup"
+    }
+  }
+
+  iceberg = {
+    catalogs = [{
+      name                     = "catalog1"
+      type                     = "S3"
+      anonymous_access_enabled = false
+      maintenance = {
+        enabled = true
+      }
+      watches = [{
+        table = "db.table"
+      }]
+    }]
+  }
+
+  metrics_endpoint = {
+    enabled          = true
+    source_ip_ranges = ["0.0.0.0/0"]
+  }
 
   force_destroy                   = true
   skip_deprovision_on_destroy     = true

--- a/internal/provider/env/aws/e2e_test.go
+++ b/internal/provider/env/aws/e2e_test.go
@@ -3,7 +3,6 @@
 package env_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -11,47 +10,12 @@ import (
 )
 
 // TestE2EAltinityCloudEnvAWS drives create -> update against the dev control
-// plane (https://anywhere.dev.altinity.cloud) using a dummy-prefixed env, and
-// asserts there is no drift after each apply (a non-empty plan = drift).
-//
-// The config exercises every settable field of the AWS env resource so the
-// drift check validates the full spec round-trip (toSDK -> API -> toModel).
-//
-// Teardown is intentionally skipped: deleting an env on dev requires MFA
-// confirmation, which CI cannot provide. Dummy-prefixed envs are cleaned up out
-// of band.
+// plane using a dummy-prefixed env, asserting no drift after each apply. The
+// config exercises every settable field so the drift check validates the full
+// spec round-trip (toSDK -> API -> toModel). Teardown is skipped (dev delete
+// requires MFA).
 func TestE2EAltinityCloudEnvAWS(t *testing.T) {
-	test.E2EPreCheck(t)
-	tf, workdir := test.NewE2ETerraform(t)
-	ctx := context.Background()
-
-	envName := "dummy-e2e-aws-" + test.GenerateRandomResourceName()
-
-	// 1. Create with the full field set.
-	test.WriteE2EConfig(t, workdir, awsE2EConfig(envName, 1))
-	if err := tf.Apply(ctx); err != nil {
-		t.Fatalf("create apply failed: %s", err)
-	}
-
-	// 2. Drift check: a plan right after create must be empty.
-	if changed, err := tf.Plan(ctx); err != nil {
-		t.Fatalf("plan after create failed: %s", err)
-	} else if changed {
-		t.Fatalf("unexpected drift after create for env %s", envName)
-	}
-
-	// 3. Update (capacity 1 -> 3), then assert no drift.
-	test.WriteE2EConfig(t, workdir, awsE2EConfig(envName, 3))
-	if err := tf.Apply(ctx); err != nil {
-		t.Fatalf("update apply failed: %s", err)
-	}
-	if changed, err := tf.Plan(ctx); err != nil {
-		t.Fatalf("plan after update failed: %s", err)
-	} else if changed {
-		t.Fatalf("unexpected drift after update for env %s", envName)
-	}
-
-	t.Logf("e2e create+update+drift OK for %s (delete skipped: dev requires MFA)", envName)
+	test.RunE2ELifecycle(t, "dummy-e2e-aws-", awsE2EConfig)
 }
 
 // awsE2EConfig returns an AWS env resource that sets every settable attribute.

--- a/internal/provider/env/aws/e2e_test.go
+++ b/internal/provider/env/aws/e2e_test.go
@@ -72,13 +72,22 @@ resource "%s" "dummy" {
     },
   ]
 
-  maintenance_windows = [{
-    name            = "weekly"
-    enabled         = true
-    hour            = 2
-    length_in_hours = 4
-    days            = ["MONDAY", "TUESDAY"]
-  }]
+  maintenance_windows = [
+    {
+      name            = "weekly"
+      enabled         = true
+      hour            = 2
+      length_in_hours = 4
+      days            = ["MONDAY", "TUESDAY"]
+    },
+    {
+      name            = "weekend"
+      enabled         = false
+      hour            = 5
+      length_in_hours = 4
+      days            = ["SATURDAY", "SUNDAY"]
+    },
+  ]
 
   peering_connections = [{
     aws_account_id = "123456789012"
@@ -86,11 +95,18 @@ resource "%s" "dummy" {
     vpc_region     = "us-east-1"
   }]
 
-  endpoints = [{
-    service_name = "com.amazonaws.vpce.us-east-1.vpce-svc-12345678"
-    alias        = "b-1.dummycluster.a1b2c3.c2.kafka.us-east-1.amazonaws.com"
-    private_dns  = true
-  }]
+  endpoints = [
+    {
+      service_name = "com.amazonaws.vpce.us-east-1.vpce-svc-12345678"
+      alias        = "b-1.dummycluster.a1b2c3.c2.kafka.us-east-1.amazonaws.com"
+      private_dns  = true
+    },
+    {
+      service_name = "com.amazonaws.vpce.us-east-1.vpce-svc-87654321"
+      alias        = "b-2.dummycluster.a1b2c3.c2.kafka.us-east-1.amazonaws.com"
+      private_dns  = false
+    },
+  ]
 
   tags = [{
     key   = "team"

--- a/internal/provider/env/aws/e2e_test.go
+++ b/internal/provider/env/aws/e2e_test.go
@@ -1,0 +1,75 @@
+//go:build e2e
+
+package env_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/test"
+)
+
+// TestE2EAltinityCloudEnvAWS drives create -> update against the dev control
+// plane (https://anywhere.dev.altinity.cloud) using a dummy-prefixed env, and
+// asserts there is no drift after each apply (a non-empty plan = drift).
+//
+// Teardown is intentionally skipped: deleting an env on dev requires MFA
+// confirmation, which CI cannot provide. Dummy-prefixed envs are cleaned up out
+// of band.
+func TestE2EAltinityCloudEnvAWS(t *testing.T) {
+	test.E2EPreCheck(t)
+	tf, workdir := test.NewE2ETerraform(t)
+	ctx := context.Background()
+
+	envName := "dummy-e2e-aws-" + test.GenerateRandomResourceName()
+
+	// 1. Create.
+	test.WriteE2EConfig(t, workdir, awsE2EConfig(envName, 1))
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("create apply failed: %s", err)
+	}
+
+	// 2. Drift check: a plan right after create must be empty.
+	if changed, err := tf.Plan(ctx); err != nil {
+		t.Fatalf("plan after create failed: %s", err)
+	} else if changed {
+		t.Fatalf("unexpected drift after create for env %s", envName)
+	}
+
+	// 3. Update (capacity 1 -> 3), then assert no drift.
+	test.WriteE2EConfig(t, workdir, awsE2EConfig(envName, 3))
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("update apply failed: %s", err)
+	}
+	if changed, err := tf.Plan(ctx); err != nil {
+		t.Fatalf("plan after update failed: %s", err)
+	} else if changed {
+		t.Fatalf("unexpected drift after update for env %s", envName)
+	}
+
+	t.Logf("e2e create+update+drift OK for %s (delete skipped: dev requires MFA)", envName)
+}
+
+func awsE2EConfig(envName string, capacity int) string {
+	return fmt.Sprintf(`
+resource "%s" "dummy" {
+  name           = "%s"
+  cidr           = "10.0.0.0/16"
+  region         = "us-east-1"
+  aws_account_id = "123456789012"
+  zones          = ["us-east-1a", "us-east-1b"]
+
+  node_groups = [{
+    zones             = ["us-east-1a"]
+    node_type         = "t4g.large"
+    capacity_per_zone = %d
+    reservations      = ["SYSTEM", "CLICKHOUSE", "ZOOKEEPER"]
+  }]
+
+  force_destroy                   = true
+  skip_deprovision_on_destroy     = true
+  allow_delete_while_disconnected = true
+}
+`, RESOURCE_NAME, envName, capacity)
+}

--- a/internal/provider/env/aws/model.go
+++ b/internal/provider/env/aws/model.go
@@ -245,6 +245,15 @@ func (model *AWSEnvResourceModel) toModel(env sdk.GetAWSEnv_AWSEnv) diag.Diagnos
 	nodeGroups, diags := nodeGroupsToModel(env.Spec.NodeGroups)
 	allDiags.Append(diags...)
 	model.NodeGroups = nodeGroups
+	// Reorder list fields the API may return out of config order, to avoid drift.
+	env.Spec.MaintenanceWindows = common.ReorderByKey(model.MaintenanceWindows, env.Spec.MaintenanceWindows,
+		func(m common.MaintenanceWindowModel) string { return m.Name.ValueString() },
+		func(s *sdk.AWSEnvSpecFragment_MaintenanceWindows) string { return s.Name },
+	)
+	env.Spec.Endpoints = common.ReorderByKey(model.Endpoints, env.Spec.Endpoints,
+		func(m AWSEnvEndpointModel) string { return m.ServiceName.ValueString() },
+		func(s *sdk.AWSEnvSpecFragment_Endpoints) string { return s.ServiceName },
+	)
 	model.MaintenanceWindows = maintenanceWindowsToModel(env.Spec.MaintenanceWindows)
 	zones, diags := common.ListToModel(env.Spec.Zones)
 	allDiags.Append(diags...)

--- a/internal/provider/env/aws/model.go
+++ b/internal/provider/env/aws/model.go
@@ -585,11 +585,18 @@ func icebergToUpdateSDK(iceberg *AWSEnvIcebergModel) *sdk.IcebergUpdateInputSpec
 	}
 }
 
-func icebergCatalogName(s *sdk.AWSEnvSpecFragment_Iceberg_Catalogs) string {
-	if s.Name != nil {
-		return *s.Name
+func ptrString(s *string) string {
+	if s != nil {
+		return *s
 	}
 	return ""
+}
+
+// icebergCatalogKey builds a composite identity (name + type). name is optional,
+// so two unnamed catalogs would collide on name alone; including type reduces
+// that, and positional matching in ReorderByKey keeps it loss-safe regardless.
+func icebergCatalogKey(name, catalogType string) string {
+	return name + "\x1f" + catalogType
 }
 
 // reorderIceberg reorders the API iceberg catalogs (and each catalog's watches)
@@ -600,13 +607,17 @@ func reorderIceberg(model *AWSEnvIcebergModel, spec *sdk.AWSEnvSpecFragment_Iceb
 	}
 
 	spec.Catalogs = common.ReorderByKey(model.Catalogs, spec.Catalogs,
-		func(m AWSEnvIcebergCatalogModel) string { return m.Name.ValueString() },
-		icebergCatalogName,
+		func(m AWSEnvIcebergCatalogModel) string {
+			return icebergCatalogKey(m.Name.ValueString(), m.Type.ValueString())
+		},
+		func(s *sdk.AWSEnvSpecFragment_Iceberg_Catalogs) string {
+			return icebergCatalogKey(ptrString(s.Name), string(s.Type))
+		},
 	)
 
 	for _, mc := range model.Catalogs {
 		for _, sc := range spec.Catalogs {
-			if mc.Name.ValueString() != icebergCatalogName(sc) {
+			if icebergCatalogKey(mc.Name.ValueString(), mc.Type.ValueString()) != icebergCatalogKey(ptrString(sc.Name), string(sc.Type)) {
 				continue
 			}
 			sc.Watches = common.ReorderByKey(mc.Watches, sc.Watches,

--- a/internal/provider/env/aws/model.go
+++ b/internal/provider/env/aws/model.go
@@ -306,6 +306,8 @@ func (model *AWSEnvResourceModel) toModel(env sdk.GetAWSEnv_AWSEnv) diag.Diagnos
 		})
 	}
 
+	reorderIceberg(model.Iceberg, env.Spec.Iceberg)
+
 	backups := backupsToModel(env.Spec.Backups)
 	iceberg := icebergToModel(env.Spec.Iceberg)
 
@@ -580,6 +582,39 @@ func icebergToUpdateSDK(iceberg *AWSEnvIcebergModel) *sdk.IcebergUpdateInputSpec
 
 	return &sdk.IcebergUpdateInputSpec{
 		Catalogs: catalogs,
+	}
+}
+
+func icebergCatalogName(s *sdk.AWSEnvSpecFragment_Iceberg_Catalogs) string {
+	if s.Name != nil {
+		return *s.Name
+	}
+	return ""
+}
+
+// reorderIceberg reorders the API iceberg catalogs (and each catalog's watches)
+// into the user's configured order to avoid drift. Mutates spec in place.
+func reorderIceberg(model *AWSEnvIcebergModel, spec *sdk.AWSEnvSpecFragment_Iceberg) {
+	if model == nil || spec == nil {
+		return
+	}
+
+	spec.Catalogs = common.ReorderByKey(model.Catalogs, spec.Catalogs,
+		func(m AWSEnvIcebergCatalogModel) string { return m.Name.ValueString() },
+		icebergCatalogName,
+	)
+
+	for _, mc := range model.Catalogs {
+		for _, sc := range spec.Catalogs {
+			if mc.Name.ValueString() != icebergCatalogName(sc) {
+				continue
+			}
+			sc.Watches = common.ReorderByKey(mc.Watches, sc.Watches,
+				func(m AWSEnvIcebergCatalogWatchModel) string { return m.Table.ValueString() },
+				func(s *sdk.AWSEnvSpecFragment_Iceberg_Catalogs_Watches) string { return s.Table },
+			)
+			break
+		}
 	}
 }
 

--- a/internal/provider/env/aws/model.go
+++ b/internal/provider/env/aws/model.go
@@ -254,6 +254,18 @@ func (model *AWSEnvResourceModel) toModel(env sdk.GetAWSEnv_AWSEnv) diag.Diagnos
 		func(m AWSEnvEndpointModel) string { return m.ServiceName.ValueString() },
 		func(s *sdk.AWSEnvSpecFragment_Endpoints) string { return s.ServiceName },
 	)
+	env.Spec.PeeringConnections = common.ReorderByKey(model.PeeringConnections, env.Spec.PeeringConnections,
+		func(m AWSEnvPeeringConnectionModel) string { return m.VpcID.ValueString() },
+		func(s *sdk.AWSEnvSpecFragment_PeeringConnections) string { return s.VpcID },
+	)
+	env.Spec.Tags = common.ReorderByKey(model.Tags, env.Spec.Tags,
+		func(m common.KeyValueModel) string { return m.Key.ValueString() },
+		func(s *sdk.AWSEnvSpecFragment_Tags) string { return s.Key },
+	)
+	env.Spec.ExternalBuckets = common.ReorderByKey(model.ExternalBuckets, env.Spec.ExternalBuckets,
+		func(m AWSEnvExternalBucketModel) string { return m.Name.ValueString() },
+		func(s *sdk.AWSEnvSpecFragment_ExternalBuckets) string { return s.Name },
+	)
 	model.MaintenanceWindows = maintenanceWindowsToModel(env.Spec.MaintenanceWindows)
 	zones, diags := common.ListToModel(env.Spec.Zones)
 	allDiags.Append(diags...)

--- a/internal/provider/env/aws/model_test.go
+++ b/internal/provider/env/aws/model_test.go
@@ -2489,3 +2489,47 @@ func TestIcebergToUpdateSDK(t *testing.T) {
 		})
 	}
 }
+
+func TestReorderIceberg(t *testing.T) {
+	name := func(s string) *string { return &s }
+
+	model := &AWSEnvIcebergModel{
+		Catalogs: []AWSEnvIcebergCatalogModel{
+			{
+				Name: types.StringValue("cat-b"),
+				Watches: []AWSEnvIcebergCatalogWatchModel{
+					{Table: types.StringValue("t2")},
+					{Table: types.StringValue("t1")},
+				},
+			},
+			{Name: types.StringValue("cat-a")},
+		},
+	}
+	spec := &sdk.AWSEnvSpecFragment_Iceberg{
+		Catalogs: []*sdk.AWSEnvSpecFragment_Iceberg_Catalogs{
+			{Name: name("cat-a")},
+			{
+				Name: name("cat-b"),
+				Watches: []*sdk.AWSEnvSpecFragment_Iceberg_Catalogs_Watches{
+					{Table: "t1"},
+					{Table: "t2"},
+				},
+			},
+		},
+	}
+
+	reorderIceberg(model, spec)
+
+	if got := []string{*spec.Catalogs[0].Name, *spec.Catalogs[1].Name}; got[0] != "cat-b" || got[1] != "cat-a" {
+		t.Errorf("catalog order = %v, want [cat-b cat-a]", got)
+	}
+	catB := spec.Catalogs[0]
+	if got := []string{catB.Watches[0].Table, catB.Watches[1].Table}; got[0] != "t2" || got[1] != "t1" {
+		t.Errorf("watch order = %v, want [t2 t1]", got)
+	}
+}
+
+func TestReorderIcebergNilSafe(t *testing.T) {
+	reorderIceberg(nil, &sdk.AWSEnvSpecFragment_Iceberg{})
+	reorderIceberg(&AWSEnvIcebergModel{}, nil)
+}

--- a/internal/provider/env/aws/resource.go
+++ b/internal/provider/env/aws/resource.go
@@ -93,6 +93,10 @@ func (r *AWSEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 	data.SpecRevision = types.Int64Value(apiResp.CreateAWSEnv.SpecRevision)
 	data.ResourcePrefix = types.StringValue(apiResp.CreateAWSEnv.Spec.ResourcePrefix)
 
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	tflog.Trace(ctx, "created resource", map[string]interface{}{"name": envName})
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
@@ -192,6 +196,10 @@ func (r *AWSEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 	resp.Diagnostics.Append(diags...)
 	data.SpecRevision = types.Int64Value(apiResp.UpdateAWSEnv.SpecRevision)
 	data.ResourcePrefix = types.StringValue(apiResp.UpdateAWSEnv.Spec.ResourcePrefix)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": envName})
 	diags = resp.State.Set(ctx, &data)

--- a/internal/provider/env/aws/schema.go
+++ b/internal/provider/env/aws/schema.go
@@ -84,7 +84,7 @@ func (d *AWSEnvDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 			"node_groups":                     common.GetNodeGroupsAttribute(false, false, true),
 			"aws_account_id":                  getAWSAccountIDAttribute(false, false, true),
 			"region":                          common.GetRegionAttribute(false, false, true, common.AWS_REGION_DESCRIPTION),
-			"nat":                             getNATAttribute(false, true, true),
+			"nat":                             getNATAttribute(false, false, true),
 			"peering_connections":             getPeeringConnectionsAttribute(false, false, true),
 			"endpoints":                       getEndpointsAttribute(false, false, true),
 			"tags":                            getTagsAttribute(false, false, true),

--- a/internal/provider/env/azure/model.go
+++ b/internal/provider/env/azure/model.go
@@ -161,6 +161,11 @@ func (model *AzureEnvResourceModel) toModel(env client.GetAzureEnv_AzureEnv) dia
 	allDiags.Append(diags...)
 	model.NodeGroups = nodeGroups
 
+	// Reorder maintenance windows the API may return out of config order, to avoid drift.
+	env.Spec.MaintenanceWindows = common.ReorderByKey(model.MaintenanceWindows, env.Spec.MaintenanceWindows,
+		func(m common.MaintenanceWindowModel) string { return m.Name.ValueString() },
+		func(s *client.AzureEnvSpecFragment_MaintenanceWindows) string { return s.Name },
+	)
 	model.MaintenanceWindows = maintenanceWindowsToModel(env.Spec.MaintenanceWindows)
 
 	zones, diags := common.ListToModel(env.Spec.Zones)

--- a/internal/provider/env/azure/model.go
+++ b/internal/provider/env/azure/model.go
@@ -161,10 +161,14 @@ func (model *AzureEnvResourceModel) toModel(env client.GetAzureEnv_AzureEnv) dia
 	allDiags.Append(diags...)
 	model.NodeGroups = nodeGroups
 
-	// Reorder maintenance windows the API may return out of config order, to avoid drift.
+	// Reorder list fields the API may return out of config order, to avoid drift.
 	env.Spec.MaintenanceWindows = common.ReorderByKey(model.MaintenanceWindows, env.Spec.MaintenanceWindows,
 		func(m common.MaintenanceWindowModel) string { return m.Name.ValueString() },
 		func(s *client.AzureEnvSpecFragment_MaintenanceWindows) string { return s.Name },
+	)
+	env.Spec.Tags = common.ReorderByKey(model.Tags, env.Spec.Tags,
+		func(m common.KeyValueModel) string { return m.Key.ValueString() },
+		func(s *client.AzureEnvSpecFragment_Tags) string { return s.Key },
 	)
 	model.MaintenanceWindows = maintenanceWindowsToModel(env.Spec.MaintenanceWindows)
 

--- a/internal/provider/env/azure/resource.go
+++ b/internal/provider/env/azure/resource.go
@@ -89,6 +89,10 @@ func (r *AzureEnvResource) Create(ctx context.Context, req resource.CreateReques
 	resp.Diagnostics.Append(diags...)
 	data.SpecRevision = types.Int64Value(apiResp.CreateAzureEnv.SpecRevision)
 
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	tflog.Trace(ctx, "created resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
@@ -180,6 +184,10 @@ func (r *AzureEnvResource) Update(ctx context.Context, req resource.UpdateReques
 	data.NodeGroups, diags = nodeGroupsToModel(apiResp.UpdateAzureEnv.Spec.NodeGroups)
 	resp.Diagnostics.Append(diags...)
 	data.SpecRevision = types.Int64Value(apiResp.UpdateAzureEnv.SpecRevision)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)

--- a/internal/provider/env/common/model.go
+++ b/internal/provider/env/common/model.go
@@ -36,22 +36,30 @@ type MaintenanceWindowModel struct {
 	Days          []types.String `tfsdk:"days"`
 }
 
+// ReorderByKey returns items reordered to match the order of model, pairing by
+// key. Matching is positional: each model entry consumes the first not-yet-used
+// item with the same key, so duplicate keys (valid for e.g. tolerations or
+// unnamed catalogs) pair in config order instead of collapsing to the first
+// match. Every item is emitted exactly once; items with no model counterpart
+// are appended at the end. The result always has len(items) elements — no
+// duplication, no loss.
 func ReorderByKey[M any, S any](model []M, items []S, getModelKey func(M) string, getItemKey func(S) string) []S {
 	ordered := make([]S, 0, len(items))
-	used := make(map[string]bool)
+	used := make([]bool, len(items))
 
 	for _, m := range model {
-		for _, item := range items {
-			if getModelKey(m) == getItemKey(item) {
+		mk := getModelKey(m)
+		for i, item := range items {
+			if !used[i] && mk == getItemKey(item) {
 				ordered = append(ordered, item)
-				used[getItemKey(item)] = true
+				used[i] = true
 				break
 			}
 		}
 	}
 
-	for _, item := range items {
-		if !used[getItemKey(item)] {
+	for i, item := range items {
+		if !used[i] {
 			ordered = append(ordered, item)
 		}
 	}

--- a/internal/provider/env/common/model_test.go
+++ b/internal/provider/env/common/model_test.go
@@ -91,6 +91,45 @@ func TestReorderByKey(t *testing.T) {
 	}
 }
 
+// Duplicate keys (valid for tolerations, unnamed catalogs, same-named windows)
+// must not collapse to the first match or drop entries.
+func TestReorderByKeyDuplicateKeys(t *testing.T) {
+	type item struct{ Key, Value string }
+
+	t.Run("empty keys preserved positionally", func(t *testing.T) {
+		model := []item{{Key: "", Value: "B"}, {Key: "", Value: "A"}}
+		items := []item{{Key: "", Value: "A"}, {Key: "", Value: "B"}}
+		result := ReorderByKey(model, items,
+			func(m item) string { return m.Key },
+			func(s item) string { return s.Key },
+		)
+		if len(result) != 2 {
+			t.Fatalf("expected 2 items, got %d (%v)", len(result), result)
+		}
+		// Both originals present, none duplicated.
+		seen := map[string]int{}
+		for _, r := range result {
+			seen[r.Value]++
+		}
+		if seen["A"] != 1 || seen["B"] != 1 {
+			t.Fatalf("expected one A and one B, got %v", seen)
+		}
+	})
+
+	t.Run("shared key matches distinct values", func(t *testing.T) {
+		// e.g. two tolerations with key "dedicated" but different values.
+		model := []item{{Key: "k", Value: "v2"}, {Key: "k", Value: "v1"}}
+		items := []item{{Key: "k", Value: "v1"}, {Key: "k", Value: "v2"}}
+		result := ReorderByKey(model, items,
+			func(m item) string { return m.Key },
+			func(s item) string { return s.Key },
+		)
+		if len(result) != 2 || result[0].Value == result[1].Value {
+			t.Fatalf("expected both distinct values preserved, got %v", result)
+		}
+	})
+}
+
 func TestReorderList(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/provider/env/gcp/e2e_test.go
+++ b/internal/provider/env/gcp/e2e_test.go
@@ -3,7 +3,6 @@
 package env_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -15,33 +14,7 @@ import (
 // config exercises every settable field so the drift check validates the full
 // spec round-trip. Teardown is skipped (dev delete requires MFA).
 func TestE2EAltinityCloudEnvGCP(t *testing.T) {
-	test.E2EPreCheck(t)
-	tf, workdir := test.NewE2ETerraform(t)
-	ctx := context.Background()
-
-	envName := "dummy-e2e-gcp-" + test.GenerateRandomResourceName()
-
-	test.WriteE2EConfig(t, workdir, gcpE2EConfig(envName, 1))
-	if err := tf.Apply(ctx); err != nil {
-		t.Fatalf("create apply failed: %s", err)
-	}
-	if changed, err := tf.Plan(ctx); err != nil {
-		t.Fatalf("plan after create failed: %s", err)
-	} else if changed {
-		t.Fatalf("unexpected drift after create for env %s", envName)
-	}
-
-	test.WriteE2EConfig(t, workdir, gcpE2EConfig(envName, 3))
-	if err := tf.Apply(ctx); err != nil {
-		t.Fatalf("update apply failed: %s", err)
-	}
-	if changed, err := tf.Plan(ctx); err != nil {
-		t.Fatalf("plan after update failed: %s", err)
-	} else if changed {
-		t.Fatalf("unexpected drift after update for env %s", envName)
-	}
-
-	t.Logf("e2e create+update+drift OK for %s (delete skipped: dev requires MFA)", envName)
+	test.RunE2ELifecycle(t, "dummy-e2e-gcp-", gcpE2EConfig)
 }
 
 // gcpE2EConfig returns a GCP env resource that sets every settable attribute.

--- a/internal/provider/env/gcp/e2e_test.go
+++ b/internal/provider/env/gcp/e2e_test.go
@@ -47,7 +47,7 @@ resource "%s" "dummy" {
 
   node_groups = [
     {
-      zones             = ["us-east1-b"]
+      zones             = ["us-east1-b", "us-east1-c"]
       node_type         = "c2-standard-16"
       capacity_per_zone = %d
       reservations      = ["SYSTEM", "ZOOKEEPER"]

--- a/internal/provider/env/gcp/e2e_test.go
+++ b/internal/provider/env/gcp/e2e_test.go
@@ -1,0 +1,120 @@
+//go:build e2e
+
+package env_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/test"
+)
+
+// TestE2EAltinityCloudEnvGCP drives create -> update against the dev control
+// plane using a dummy-prefixed env, asserting no drift after each apply. The
+// config exercises every settable field so the drift check validates the full
+// spec round-trip. Teardown is skipped (dev delete requires MFA).
+func TestE2EAltinityCloudEnvGCP(t *testing.T) {
+	test.E2EPreCheck(t)
+	tf, workdir := test.NewE2ETerraform(t)
+	ctx := context.Background()
+
+	envName := "dummy-e2e-gcp-" + test.GenerateRandomResourceName()
+
+	test.WriteE2EConfig(t, workdir, gcpE2EConfig(envName, 1))
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("create apply failed: %s", err)
+	}
+	if changed, err := tf.Plan(ctx); err != nil {
+		t.Fatalf("plan after create failed: %s", err)
+	} else if changed {
+		t.Fatalf("unexpected drift after create for env %s", envName)
+	}
+
+	test.WriteE2EConfig(t, workdir, gcpE2EConfig(envName, 3))
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("update apply failed: %s", err)
+	}
+	if changed, err := tf.Plan(ctx); err != nil {
+		t.Fatalf("plan after update failed: %s", err)
+	} else if changed {
+		t.Fatalf("unexpected drift after update for env %s", envName)
+	}
+
+	t.Logf("e2e create+update+drift OK for %s (delete skipped: dev requires MFA)", envName)
+}
+
+// gcpE2EConfig returns a GCP env resource that sets every settable attribute.
+// capacity drives the mutable change exercised by the update step.
+//
+// Intentionally omitted: datadog (enabling requires an encrypted API key);
+// custom_domain (superseded by custom_domains).
+func gcpE2EConfig(envName string, capacity int) string {
+	return fmt.Sprintf(`
+resource "%s" "dummy" {
+  name           = "%s"
+  cidr           = "10.0.0.0/16"
+  region         = "us-east1"
+  gcp_project_id = "dummy-project-e2e"
+  zones          = ["us-east1-b", "us-east1-c"]
+
+  custom_domains          = ["e2e.example.com"]
+  load_balancing_strategy = "ROUND_ROBIN"
+
+  load_balancers = {
+    public = {
+      enabled          = true
+      source_ip_ranges = ["0.0.0.0/0"]
+    }
+    internal = {
+      enabled          = true
+      source_ip_ranges = ["10.0.0.0/8"]
+    }
+  }
+
+  node_groups = [
+    {
+      zones             = ["us-east1-b"]
+      node_type         = "c2-standard-16"
+      capacity_per_zone = %d
+      reservations      = ["SYSTEM", "ZOOKEEPER"]
+    },
+    {
+      zones             = ["us-east1-c"]
+      node_type         = "n2-standard-8"
+      capacity_per_zone = 2
+      reservations      = ["CLICKHOUSE"]
+    },
+  ]
+
+  maintenance_windows = [{
+    name            = "weekly"
+    enabled         = true
+    hour            = 2
+    length_in_hours = 4
+    days            = ["MONDAY", "TUESDAY", "WEDNESDAY"]
+  }]
+
+  peering_connections = [{
+    project_id   = "dummy-project-e2e"
+    network_name = "my-network"
+  }]
+
+  private_service_consumers = ["dummy-consumer-proj"]
+
+  labels = [{
+    key   = "team"
+    value = "platform"
+  }]
+
+  metrics_endpoint = {
+    enabled          = true
+    source_ip_ranges = ["0.0.0.0/0"]
+  }
+
+  force_destroy                   = true
+  skip_deprovision_on_destroy     = true
+  allow_delete_while_disconnected = true
+}
+`, RESOURCE_NAME, envName, capacity)
+}

--- a/internal/provider/env/gcp/e2e_test.go
+++ b/internal/provider/env/gcp/e2e_test.go
@@ -60,13 +60,22 @@ resource "%s" "dummy" {
     },
   ]
 
-  maintenance_windows = [{
-    name            = "weekly"
-    enabled         = true
-    hour            = 2
-    length_in_hours = 4
-    days            = ["MONDAY", "TUESDAY", "WEDNESDAY"]
-  }]
+  maintenance_windows = [
+    {
+      name            = "weekly"
+      enabled         = true
+      hour            = 2
+      length_in_hours = 4
+      days            = ["MONDAY", "TUESDAY", "WEDNESDAY"]
+    },
+    {
+      name            = "biweekly"
+      enabled         = false
+      hour            = 6
+      length_in_hours = 4
+      days            = ["THURSDAY", "FRIDAY", "SATURDAY"]
+    },
+  ]
 
   peering_connections = [{
     project_id   = "dummy-project-e2e"

--- a/internal/provider/env/gcp/model.go
+++ b/internal/provider/env/gcp/model.go
@@ -167,10 +167,18 @@ func (model *GCPEnvResourceModel) toModel(env sdk.GetGCPEnv_GCPEnv) diag.Diagnos
 	allDiags.Append(diags...)
 	model.NodeGroups = nodeGroups
 
-	// Reorder maintenance windows the API may return out of config order, to avoid drift.
+	// Reorder list fields the API may return out of config order, to avoid drift.
 	env.Spec.MaintenanceWindows = common.ReorderByKey(model.MaintenanceWindows, env.Spec.MaintenanceWindows,
 		func(m common.MaintenanceWindowModel) string { return m.Name.ValueString() },
 		func(s *sdk.GCPEnvSpecFragment_MaintenanceWindows) string { return s.Name },
+	)
+	env.Spec.PeeringConnections = common.ReorderByKey(model.PeeringConnections, env.Spec.PeeringConnections,
+		func(m GCPEnvPeeringConnectionModel) string { return m.NetworkName.ValueString() },
+		func(s *sdk.GCPEnvSpecFragment_PeeringConnections) string { return s.NetworkName },
+	)
+	env.Spec.Labels = common.ReorderByKey(model.Labels, env.Spec.Labels,
+		func(m common.KeyValueModel) string { return m.Key.ValueString() },
+		func(s *sdk.GCPEnvSpecFragment_Labels) string { return s.Key },
 	)
 	model.MaintenanceWindows = maintenanceWindowsToModel(env.Spec.MaintenanceWindows)
 

--- a/internal/provider/env/gcp/model.go
+++ b/internal/provider/env/gcp/model.go
@@ -167,6 +167,11 @@ func (model *GCPEnvResourceModel) toModel(env sdk.GetGCPEnv_GCPEnv) diag.Diagnos
 	allDiags.Append(diags...)
 	model.NodeGroups = nodeGroups
 
+	// Reorder maintenance windows the API may return out of config order, to avoid drift.
+	env.Spec.MaintenanceWindows = common.ReorderByKey(model.MaintenanceWindows, env.Spec.MaintenanceWindows,
+		func(m common.MaintenanceWindowModel) string { return m.Name.ValueString() },
+		func(s *sdk.GCPEnvSpecFragment_MaintenanceWindows) string { return s.Name },
+	)
 	model.MaintenanceWindows = maintenanceWindowsToModel(env.Spec.MaintenanceWindows)
 
 	zones, diags := common.ListToModel(env.Spec.Zones)

--- a/internal/provider/env/gcp/resource.go
+++ b/internal/provider/env/gcp/resource.go
@@ -93,6 +93,10 @@ func (r *GCPEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 	resp.Diagnostics.Append(diags...)
 	data.SpecRevision = types.Int64Value(apiResp.CreateGCPEnv.SpecRevision)
 
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	tflog.Trace(ctx, "created resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
@@ -192,6 +196,10 @@ func (r *GCPEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 	data.NodeGroups, diags = nodeGroupsToModel(apiResp.UpdateGCPEnv.Spec.NodeGroups)
 	resp.Diagnostics.Append(diags...)
 	data.SpecRevision = types.Int64Value(apiResp.UpdateGCPEnv.SpecRevision)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)

--- a/internal/provider/env/hcloud/model.go
+++ b/internal/provider/env/hcloud/model.go
@@ -151,12 +151,21 @@ func (model *HCloudEnvResourceModel) toModel(env client.GetHCloudEnv_HcloudEnv) 
 	allDiags.Append(diags...)
 	model.NodeGroups = nodeGroups
 
+	// Reorder maintenance windows the API may return out of config order, to avoid drift.
+	env.Spec.MaintenanceWindows = common.ReorderByKey(model.MaintenanceWindows, env.Spec.MaintenanceWindows,
+		func(m common.MaintenanceWindowModel) string { return m.Name.ValueString() },
+		func(s *client.HCloudEnvSpecFragment_MaintenanceWindows) string { return s.Name },
+	)
 	model.MaintenanceWindows = maintenanceWindowsToModel(env.Spec.MaintenanceWindows)
 
 	locations, diags := common.ListToModel(env.Spec.Locations)
 	allDiags.Append(diags...)
 	model.Locations = locations
 
+	env.Spec.WireguardPeers = common.ReorderByKey(model.WireguardPeers, env.Spec.WireguardPeers,
+		func(m WireguardPeers) string { return m.PublicKey.ValueString() },
+		func(s *client.HCloudEnvSpecFragment_WireguardPeers) string { return s.PublicKey },
+	)
 	wireguardPeers, diags := wireguardPeersToModel(env.Spec.WireguardPeers)
 	allDiags.Append(diags...)
 	model.WireguardPeers = wireguardPeers

--- a/internal/provider/env/hcloud/resource.go
+++ b/internal/provider/env/hcloud/resource.go
@@ -85,6 +85,10 @@ func (r *HCloudEnvResource) Create(ctx context.Context, req resource.CreateReque
 	resp.Diagnostics.Append(diags...)
 	data.SpecRevision = types.Int64Value(apiResp.CreateHCloudEnv.SpecRevision)
 
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	tflog.Trace(ctx, "created resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
@@ -168,6 +172,10 @@ func (r *HCloudEnvResource) Update(ctx context.Context, req resource.UpdateReque
 	data.NodeGroups, diags = nodeGroupsToModel(apiResp.UpdateHCloudEnv.Spec.NodeGroups)
 	resp.Diagnostics.Append(diags...)
 	data.SpecRevision = types.Int64Value(apiResp.UpdateHCloudEnv.SpecRevision)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Trace(ctx, "updated resource", map[string]interface{}{"name": name})
 	diags = resp.State.Set(ctx, &data)

--- a/internal/provider/env/k8s/e2e_test.go
+++ b/internal/provider/env/k8s/e2e_test.go
@@ -65,19 +65,33 @@ resource "%s" "dummy" {
   node_groups = [
     {
       node_type         = "small"
-      zones             = ["us-east-1a"]
+      zones             = ["us-east-1a", "us-east-1b"]
       capacity_per_zone = %d
       reservations      = ["SYSTEM", "ZOOKEEPER"]
-      selector = [{
-        key   = "workload"
-        value = "system"
-      }]
-      tolerations = [{
-        key      = "dedicated"
-        value    = "system"
-        operator = "EQUAL"
-        effect   = "NO_SCHEDULE"
-      }]
+      selector = [
+        {
+          key   = "workload"
+          value = "system"
+        },
+        {
+          key   = "tier"
+          value = "infra"
+        },
+      ]
+      tolerations = [
+        {
+          key      = "dedicated"
+          value    = "system"
+          operator = "EQUAL"
+          effect   = "NO_SCHEDULE"
+        },
+        {
+          key      = "priority"
+          value    = "high"
+          operator = "EQUAL"
+          effect   = "NO_EXECUTE"
+        },
+      ]
     },
     {
       node_type         = "large"

--- a/internal/provider/env/k8s/e2e_test.go
+++ b/internal/provider/env/k8s/e2e_test.go
@@ -1,0 +1,143 @@
+//go:build e2e
+
+package env_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/test"
+)
+
+// TestE2EAltinityCloudEnvK8S drives create -> update against the dev control
+// plane using a dummy-prefixed env, asserting no drift after each apply. The
+// config exercises every settable field so the drift check validates the full
+// spec round-trip. Teardown is skipped (dev delete requires MFA).
+func TestE2EAltinityCloudEnvK8S(t *testing.T) {
+	test.E2EPreCheck(t)
+	tf, workdir := test.NewE2ETerraform(t)
+	ctx := context.Background()
+
+	envName := "dummy-e2e-k8s-" + test.GenerateRandomResourceName()
+
+	test.WriteE2EConfig(t, workdir, k8sE2EConfig(envName, 1))
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("create apply failed: %s", err)
+	}
+	if changed, err := tf.Plan(ctx); err != nil {
+		t.Fatalf("plan after create failed: %s", err)
+	} else if changed {
+		t.Fatalf("unexpected drift after create for env %s", envName)
+	}
+
+	test.WriteE2EConfig(t, workdir, k8sE2EConfig(envName, 3))
+	if err := tf.Apply(ctx); err != nil {
+		t.Fatalf("update apply failed: %s", err)
+	}
+	if changed, err := tf.Plan(ctx); err != nil {
+		t.Fatalf("plan after update failed: %s", err)
+	} else if changed {
+		t.Fatalf("unexpected drift after update for env %s", envName)
+	}
+
+	t.Logf("e2e create+update+drift OK for %s (delete skipped: dev requires MFA)", envName)
+}
+
+// k8sE2EConfig returns a BYOK env resource that sets every settable attribute.
+// capacity drives the mutable change exercised by the update step.
+//
+// Intentionally omitted: custom_domain (superseded by custom_domains).
+func k8sE2EConfig(envName string, capacity int) string {
+	return fmt.Sprintf(`
+resource "%s" "dummy" {
+  name         = "%s"
+  distribution = "CUSTOM"
+
+  custom_domains          = ["e2e.example.com"]
+  load_balancing_strategy = "ROUND_ROBIN"
+
+  load_balancers = {
+    public = {
+      enabled          = true
+      source_ip_ranges = ["0.0.0.0/0"]
+      annotations = [{
+        key   = "service.beta.kubernetes.io/aws-load-balancer-type"
+        value = "nlb"
+      }]
+    }
+    internal = {
+      enabled          = true
+      source_ip_ranges = ["10.0.0.0/8"]
+      annotations = [{
+        key   = "service.beta.kubernetes.io/aws-load-balancer-internal"
+        value = "true"
+      }]
+    }
+  }
+
+  custom_node_types = [
+    {
+      name                     = "small"
+      cpu_allocatable          = 4
+      mem_allocatable_in_bytes = 8589934592
+    },
+    {
+      name                     = "large"
+      cpu_allocatable          = 8
+      mem_allocatable_in_bytes = 17179869184
+    },
+  ]
+
+  node_groups = [
+    {
+      node_type         = "small"
+      zones             = ["us-east-1a"]
+      capacity_per_zone = %d
+      reservations      = ["SYSTEM", "ZOOKEEPER"]
+      selector = [{
+        key   = "workload"
+        value = "system"
+      }]
+      tolerations = [{
+        key      = "dedicated"
+        value    = "system"
+        operator = "EQUAL"
+        effect   = "NO_SCHEDULE"
+      }]
+    },
+    {
+      node_type         = "large"
+      zones             = ["us-east-1b"]
+      capacity_per_zone = 2
+      reservations      = ["CLICKHOUSE"]
+    },
+  ]
+
+  maintenance_windows = [{
+    name            = "weekly"
+    enabled         = true
+    hour            = 2
+    length_in_hours = 4
+    days            = ["MONDAY", "TUESDAY", "WEDNESDAY"]
+  }]
+
+  logs = {
+    storage = {
+      s3 = {
+        bucket_name = "my-logs-bucket"
+        region      = "us-east-1"
+      }
+    }
+  }
+
+  metrics = {
+    retention_period_in_days = 30
+  }
+
+  force_destroy                   = true
+  skip_deprovision_on_destroy     = true
+  allow_delete_while_disconnected = true
+}
+`, RESOURCE_NAME, envName, capacity)
+}

--- a/internal/provider/env/k8s/e2e_test.go
+++ b/internal/provider/env/k8s/e2e_test.go
@@ -87,13 +87,22 @@ resource "%s" "dummy" {
     },
   ]
 
-  maintenance_windows = [{
-    name            = "weekly"
-    enabled         = true
-    hour            = 2
-    length_in_hours = 4
-    days            = ["MONDAY", "TUESDAY", "WEDNESDAY"]
-  }]
+  maintenance_windows = [
+    {
+      name            = "weekly"
+      enabled         = true
+      hour            = 2
+      length_in_hours = 4
+      days            = ["MONDAY", "TUESDAY", "WEDNESDAY"]
+    },
+    {
+      name            = "biweekly"
+      enabled         = true
+      hour            = 6
+      length_in_hours = 4
+      days            = ["THURSDAY", "FRIDAY", "SATURDAY"]
+    },
+  ]
 
   logs = {
     storage = {

--- a/internal/provider/env/k8s/e2e_test.go
+++ b/internal/provider/env/k8s/e2e_test.go
@@ -3,7 +3,6 @@
 package env_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -15,33 +14,7 @@ import (
 // config exercises every settable field so the drift check validates the full
 // spec round-trip. Teardown is skipped (dev delete requires MFA).
 func TestE2EAltinityCloudEnvK8S(t *testing.T) {
-	test.E2EPreCheck(t)
-	tf, workdir := test.NewE2ETerraform(t)
-	ctx := context.Background()
-
-	envName := "dummy-e2e-k8s-" + test.GenerateRandomResourceName()
-
-	test.WriteE2EConfig(t, workdir, k8sE2EConfig(envName, 1))
-	if err := tf.Apply(ctx); err != nil {
-		t.Fatalf("create apply failed: %s", err)
-	}
-	if changed, err := tf.Plan(ctx); err != nil {
-		t.Fatalf("plan after create failed: %s", err)
-	} else if changed {
-		t.Fatalf("unexpected drift after create for env %s", envName)
-	}
-
-	test.WriteE2EConfig(t, workdir, k8sE2EConfig(envName, 3))
-	if err := tf.Apply(ctx); err != nil {
-		t.Fatalf("update apply failed: %s", err)
-	}
-	if changed, err := tf.Plan(ctx); err != nil {
-		t.Fatalf("plan after update failed: %s", err)
-	} else if changed {
-		t.Fatalf("unexpected drift after update for env %s", envName)
-	}
-
-	t.Logf("e2e create+update+drift OK for %s (delete skipped: dev requires MFA)", envName)
+	test.RunE2ELifecycle(t, "dummy-e2e-k8s-", k8sE2EConfig)
 }
 
 // k8sE2EConfig returns a BYOK env resource that sets every settable attribute.

--- a/internal/provider/env/k8s/model.go
+++ b/internal/provider/env/k8s/model.go
@@ -156,6 +156,12 @@ func (model *K8SEnvResourceModel) toModel(name string, specRevision int64, spec 
 	model.CustomDomain = customDomain
 	model.CustomDomains = customDomains
 	model.LoadBalancingStrategy = types.StringValue(string(spec.LoadBalancingStrategy))
+	// Reorder custom node types to respect order in the user's configuration; the
+	// API may return them in a different order, which would otherwise drift.
+	spec.CustomNodeTypes = common.ReorderByKey(model.CustomNodeTypes, spec.CustomNodeTypes,
+		func(m NodeTypeModel) string { return m.Name.ValueString() },
+		func(s *client.K8SEnvSpecFragment_CustomNodeTypes) string { return s.Name },
+	)
 	model.CustomNodeTypes = nodeTypesToModel(spec.CustomNodeTypes)
 	nodeGroups, diags := nodeGroupsToModel(spec.NodeGroups)
 	allDiags.Append(diags...)

--- a/internal/provider/env/k8s/model.go
+++ b/internal/provider/env/k8s/model.go
@@ -480,6 +480,17 @@ func nodeGroupMatches(m NodeGroupsModel, s *client.K8SEnvSpecFragment_NodeGroups
 
 // reorderNodeGroups returns the API node groups in config order: each config
 // group pulls its match to the front, then any API-only groups follow.
+// selectorKey/tolerationKey build a composite identity from all fields so
+// entries that share a key (valid for both) reorder by full identity instead of
+// collapsing on key alone. \x1f (unit separator) can't appear in these values.
+func selectorKey(key, value string) string {
+	return key + "\x1f" + value
+}
+
+func tolerationKey(key, value, operator, effect string) string {
+	return key + "\x1f" + value + "\x1f" + operator + "\x1f" + effect
+}
+
 func reorderNodeGroups(model []NodeGroupsModel, items []*client.K8SEnvSpecFragment_NodeGroups) []*client.K8SEnvSpecFragment_NodeGroups {
 	ordered := make([]*client.K8SEnvSpecFragment_NodeGroups, 0, len(items))
 	used := make([]bool, len(items))
@@ -503,12 +514,16 @@ func reorderNodeGroups(model []NodeGroupsModel, items []*client.K8SEnvSpecFragme
 		for _, apiGroup := range ordered {
 			if nodeGroupMatches(ng, apiGroup) {
 				apiGroup.Selector = common.ReorderByKey(ng.NodeSelector, apiGroup.Selector,
-					func(m common.KeyValueModel) string { return m.Key.ValueString() },
-					func(s *client.K8SEnvSpecFragment_NodeGroups_Selector) string { return s.Key },
+					func(m common.KeyValueModel) string { return selectorKey(m.Key.ValueString(), m.Value.ValueString()) },
+					func(s *client.K8SEnvSpecFragment_NodeGroups_Selector) string { return selectorKey(s.Key, s.Value) },
 				)
 				apiGroup.Tolerations = common.ReorderByKey(ng.Tolerations, apiGroup.Tolerations,
-					func(m TolerationModel) string { return m.Key.ValueString() },
-					func(s *client.K8SEnvSpecFragment_NodeGroups_Tolerations) string { return s.Key },
+					func(m TolerationModel) string {
+						return tolerationKey(m.Key.ValueString(), m.Value.ValueString(), m.Operator.ValueString(), m.Effect.ValueString())
+					},
+					func(s *client.K8SEnvSpecFragment_NodeGroups_Tolerations) string {
+						return tolerationKey(s.Key, s.Value, string(s.Operator), string(s.Effect))
+					},
 				)
 				break
 			}

--- a/internal/provider/env/k8s/model.go
+++ b/internal/provider/env/k8s/model.go
@@ -166,7 +166,7 @@ func (model *K8SEnvResourceModel) toModel(name string, specRevision int64, spec 
 	nodeGroups, diags := nodeGroupsToModel(spec.NodeGroups)
 	allDiags.Append(diags...)
 	model.NodeGroups = nodeGroups
-	model.LoadBalancers = loadBalancersToModel(spec.LoadBalancers)
+	model.LoadBalancers = loadBalancersToModel(spec.LoadBalancers, model.LoadBalancers)
 	model.Logs = logsToModel(spec.Logs)
 	// Reorder maintenance windows the API may return out of config order, to avoid drift.
 	spec.MaintenanceWindows = common.ReorderByKey(model.MaintenanceWindows, spec.MaintenanceWindows,
@@ -211,7 +211,12 @@ func loadBalancersToSDK(loadBalancers *LoadBalancersModel) *client.K8SEnvLoadBal
 	}
 }
 
-func loadBalancersToModel(loadBalancers client.K8SEnvSpecFragment_LoadBalancers) *LoadBalancersModel {
+func reorderAnnotations(config, items []common.KeyValueModel) []common.KeyValueModel {
+	key := func(m common.KeyValueModel) string { return m.Key.ValueString() }
+	return common.ReorderByKey(config, items, key, key)
+}
+
+func loadBalancersToModel(loadBalancers client.K8SEnvSpecFragment_LoadBalancers, config *LoadBalancersModel) *LoadBalancersModel {
 	model := &LoadBalancersModel{
 		Public: &PublicLoadBalancerModel{
 			Annotations: []common.KeyValueModel{},
@@ -238,6 +243,9 @@ func loadBalancersToModel(loadBalancers client.K8SEnvSpecFragment_LoadBalancers)
 	}
 
 	model.Public.Enabled = types.BoolValue(loadBalancers.Public.Enabled)
+	if config != nil && config.Public != nil {
+		publicAnnotations = reorderAnnotations(config.Public.Annotations, publicAnnotations)
+	}
 	model.Public.Annotations = publicAnnotations
 	model.Public.SourceIPRanges = publicSourceIpRanges
 
@@ -255,6 +263,9 @@ func loadBalancersToModel(loadBalancers client.K8SEnvSpecFragment_LoadBalancers)
 	}
 
 	model.Internal.Enabled = types.BoolValue(loadBalancers.Internal.Enabled)
+	if config != nil && config.Internal != nil {
+		internalAnnotations = reorderAnnotations(config.Internal.Annotations, internalAnnotations)
+	}
 	model.Internal.Annotations = internalAnnotations
 	model.Internal.SourceIPRanges = internalSourceIpRanges
 

--- a/internal/provider/env/k8s/model.go
+++ b/internal/provider/env/k8s/model.go
@@ -168,6 +168,11 @@ func (model *K8SEnvResourceModel) toModel(name string, specRevision int64, spec 
 	model.NodeGroups = nodeGroups
 	model.LoadBalancers = loadBalancersToModel(spec.LoadBalancers)
 	model.Logs = logsToModel(spec.Logs)
+	// Reorder maintenance windows the API may return out of config order, to avoid drift.
+	spec.MaintenanceWindows = common.ReorderByKey(model.MaintenanceWindows, spec.MaintenanceWindows,
+		func(m common.MaintenanceWindowModel) string { return m.Name.ValueString() },
+		func(s *client.K8SEnvSpecFragment_MaintenanceWindows) string { return s.Name },
+	)
 	model.MaintenanceWindows = maintenanceWindowsToModel(spec.MaintenanceWindows)
 	model.Metrics = metricsToModel(spec.Metrics)
 	model.Distribution = types.StringValue(string(spec.Distribution))

--- a/internal/provider/env/k8s/model.go
+++ b/internal/provider/env/k8s/model.go
@@ -456,15 +456,41 @@ func maintenanceWindowsToModel(input []*client.K8SEnvSpecFragment_MaintenanceWin
 	return maintenanceWindow
 }
 
+// nodeGroupMatches pairs a config node group with an API one. When the user
+// set a name it is the unique identity (so two groups sharing a node_type but
+// differing by name pair correctly); otherwise name is server-computed and may
+// differ from the node type, so we fall back to matching on node_type.
+func nodeGroupMatches(m NodeGroupsModel, s *client.K8SEnvSpecFragment_NodeGroups) bool {
+	if name := m.Name.ValueString(); name != "" {
+		return name == s.Name
+	}
+	return m.NodeType.ValueString() == s.NodeType
+}
+
+// reorderNodeGroups returns the API node groups in config order: each config
+// group pulls its match to the front, then any API-only groups follow.
 func reorderNodeGroups(model []NodeGroupsModel, items []*client.K8SEnvSpecFragment_NodeGroups) []*client.K8SEnvSpecFragment_NodeGroups {
-	ordered := common.ReorderByKey(model, items,
-		func(m NodeGroupsModel) string { return m.NodeType.ValueString() },
-		func(s *client.K8SEnvSpecFragment_NodeGroups) string { return s.NodeType },
-	)
+	ordered := make([]*client.K8SEnvSpecFragment_NodeGroups, 0, len(items))
+	used := make([]bool, len(items))
+
+	for _, ng := range model {
+		for i, item := range items {
+			if !used[i] && nodeGroupMatches(ng, item) {
+				ordered = append(ordered, item)
+				used[i] = true
+				break
+			}
+		}
+	}
+	for i, item := range items {
+		if !used[i] {
+			ordered = append(ordered, item)
+		}
+	}
 
 	for _, ng := range model {
 		for _, apiGroup := range ordered {
-			if ng.NodeType.ValueString() == apiGroup.NodeType {
+			if nodeGroupMatches(ng, apiGroup) {
 				apiGroup.Selector = common.ReorderByKey(ng.NodeSelector, apiGroup.Selector,
 					func(m common.KeyValueModel) string { return m.Key.ValueString() },
 					func(s *client.K8SEnvSpecFragment_NodeGroups_Selector) string { return s.Key },

--- a/internal/provider/env/k8s/model_test.go
+++ b/internal/provider/env/k8s/model_test.go
@@ -162,6 +162,32 @@ func TestReorderNodeGroups(t *testing.T) {
 	}
 }
 
+// Two node groups sharing a node_type but with distinct user-set names must
+// pair by name, not node_type — otherwise their selectors/tolerations get
+// mispaired and state is corrupted.
+func TestReorderNodeGroupsSameTypeDistinctNames(t *testing.T) {
+	model := []NodeGroupsModel{
+		{Name: types.StringValue("ng-b"), NodeType: types.StringValue("t4g.large")},
+		{Name: types.StringValue("ng-a"), NodeType: types.StringValue("t4g.large")},
+	}
+	api := []*client.K8SEnvSpecFragment_NodeGroups{
+		{NodeType: "t4g.large", Name: "ng-a", CapacityPerZone: 1},
+		{NodeType: "t4g.large", Name: "ng-b", CapacityPerZone: 2},
+	}
+
+	result := reorderNodeGroups(model, api)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 node groups, got %d", len(result))
+	}
+	if result[0].Name != "ng-b" || result[1].Name != "ng-a" {
+		t.Errorf("expected config order [ng-b ng-a], got [%s %s]", result[0].Name, result[1].Name)
+	}
+	if result[0].CapacityPerZone != 2 || result[1].CapacityPerZone != 1 {
+		t.Errorf("capacity mispaired: got ng-b=%d ng-a=%d (want 2, 1)", result[0].CapacityPerZone, result[1].CapacityPerZone)
+	}
+}
+
 func TestReorderSelectors(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/provider/env/k8s/model_test.go
+++ b/internal/provider/env/k8s/model_test.go
@@ -717,7 +717,7 @@ func TestLoadBalancersToModel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := loadBalancersToModel(tt.input)
+			result := loadBalancersToModel(tt.input, nil)
 
 			if result == nil {
 				t.Error("Expected non-nil result")
@@ -2235,5 +2235,45 @@ func TestK8SEnvResourceModel_toModel(t *testing.T) {
 			}
 			tt.validate(t, model)
 		})
+	}
+}
+
+func TestLoadBalancersToModelReordersAnnotations(t *testing.T) {
+	lb := client.K8SEnvSpecFragment_LoadBalancers{
+		Public: client.K8SEnvSpecFragment_LoadBalancers_Public{
+			Annotations: []*client.K8SEnvSpecFragment_LoadBalancers_Public_Annotations{
+				{Key: "a", Value: "1"},
+				{Key: "b", Value: "2"},
+			},
+		},
+		Internal: client.K8SEnvSpecFragment_LoadBalancers_Internal{
+			Annotations: []*client.K8SEnvSpecFragment_LoadBalancers_Internal_Annotations{
+				{Key: "x", Value: "9"},
+				{Key: "y", Value: "8"},
+			},
+		},
+	}
+	config := &LoadBalancersModel{
+		Public: &PublicLoadBalancerModel{
+			Annotations: []common.KeyValueModel{
+				{Key: types.StringValue("b")},
+				{Key: types.StringValue("a")},
+			},
+		},
+		Internal: &InternalLoadBalancerModel{
+			Annotations: []common.KeyValueModel{
+				{Key: types.StringValue("y")},
+				{Key: types.StringValue("x")},
+			},
+		},
+	}
+
+	result := loadBalancersToModel(lb, config)
+
+	if got := result.Public.Annotations; got[0].Key.ValueString() != "b" || got[1].Key.ValueString() != "a" {
+		t.Errorf("public annotation order = [%s %s], want [b a]", got[0].Key.ValueString(), got[1].Key.ValueString())
+	}
+	if got := result.Internal.Annotations; got[0].Key.ValueString() != "y" || got[1].Key.ValueString() != "x" {
+		t.Errorf("internal annotation order = [%s %s], want [y x]", got[0].Key.ValueString(), got[1].Key.ValueString())
 	}
 }

--- a/internal/provider/env_secret/resource_test.go
+++ b/internal/provider/env_secret/resource_test.go
@@ -18,7 +18,7 @@ func TestAccAltinityCloudSecret_Basic(t *testing.T) {
 		ProtoV6ProviderFactories: test.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: GeSecretResource(),
+				Config: GetSecretResource(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAltinityCloudSecretExists(FILE_NAME),
 					resource.TestCheckResourceAttr(FILE_NAME, "value", "value"),
@@ -43,7 +43,7 @@ func testAccCheckAltinityCloudSecretExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func GeSecretResource() string {
+func GetSecretResource() string {
 	return fmt.Sprintf(`
 resource "%s" "dummy" {
   pem   = "xxx"

--- a/internal/provider/env_status/aws/data_source.go
+++ b/internal/provider/env_status/aws/data_source.go
@@ -96,6 +96,11 @@ func (d *AWSEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
+	if apiResp.AWSEnv == nil {
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
+		return
+	}
+
 	data.toModel(*apiResp.AWSEnv)
 	data.Id = data.Name
 	diags = resp.State.Set(ctx, &data)

--- a/internal/provider/env_status/azure/data_source.go
+++ b/internal/provider/env_status/azure/data_source.go
@@ -95,6 +95,11 @@ func (d *AzureEnvStatusDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
+	if apiResp.AzureEnv == nil {
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
+		return
+	}
+
 	data.toModel(*apiResp.AzureEnv)
 	data.Id = data.Name
 	diags = resp.State.Set(ctx, &data)

--- a/internal/provider/env_status/gcp/data_source.go
+++ b/internal/provider/env_status/gcp/data_source.go
@@ -95,6 +95,11 @@ func (d *GCPEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
+	if apiResp.GCPEnv == nil {
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
+		return
+	}
+
 	data.toModel(*apiResp.GCPEnv)
 	data.Id = data.Name
 	diags = resp.State.Set(ctx, &data)

--- a/internal/provider/env_status/hcloud/data_source.go
+++ b/internal/provider/env_status/hcloud/data_source.go
@@ -95,6 +95,11 @@ func (d *HCloudEnvStatusDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
+	if apiResp.HcloudEnv == nil {
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
+		return
+	}
+
 	data.toModel(*apiResp.HcloudEnv)
 	data.Id = data.Name
 	diags = resp.State.Set(ctx, &data)

--- a/internal/provider/env_status/k8s/data_source.go
+++ b/internal/provider/env_status/k8s/data_source.go
@@ -95,6 +95,11 @@ func (d *K8SEnvStatusDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
+	if apiResp.K8sEnv == nil {
+		clientsupport.AddClientError(&resp.Diagnostics, fmt.Sprintf("Environment %s was not found", envName))
+		return
+	}
+
 	data.toModel(*apiResp.K8sEnv)
 	data.Id = data.Name
 	diags = resp.State.Set(ctx, &data)

--- a/internal/provider/test/e2e.go
+++ b/internal/provider/test/e2e.go
@@ -3,10 +3,12 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -73,6 +75,106 @@ func NewE2ETerraform(t *testing.T) (*tfexec.Terraform, string) {
 		t.Fatalf("failed to init tfexec: %s", err)
 	}
 	return tf, workdir
+}
+
+// e2eTransientPatterns are control-plane/network errors worth retrying in e2e.
+// The dev control plane intermittently resets long-lived connections (~30s) on
+// heavy create requests, which surfaces as a transient apply failure from the
+// GitHub Actions runners.
+var e2eTransientPatterns = []string{
+	"connection reset by peer",
+	"connection refused",
+	"i/o timeout",
+	"TLS handshake timeout",
+	"EOF",
+	"request failed",
+	"502", "503", "504",
+}
+
+func isE2ETransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, p := range e2eTransientPatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// RunE2ELifecycle drives the standard env lifecycle against the dev control
+// plane: create -> drift check -> update -> drift check. Teardown is skipped
+// (dev delete requires MFA). configFn renders the resource HCL for a given env
+// name and node capacity (the capacity drives the mutable update).
+//
+// Create is retried with a fresh env name on transient dev errors so a reset
+// connection doesn't leave us colliding with a half-created env; the idempotent
+// update/plan steps are retried in place.
+func RunE2ELifecycle(t *testing.T, namePrefix string, configFn func(envName string, capacity int) string) {
+	t.Helper()
+	E2EPreCheck(t)
+	tf, workdir := NewE2ETerraform(t)
+	ctx := context.Background()
+
+	const maxAttempts = 3
+
+	var envName string
+	for attempt := 1; ; attempt++ {
+		envName = namePrefix + GenerateRandomResourceName()
+		WriteE2EConfig(t, workdir, configFn(envName, 1))
+		err := tf.Apply(ctx)
+		if err == nil {
+			break
+		}
+		if attempt >= maxAttempts || !isE2ETransient(err) {
+			t.Fatalf("create apply failed: %s", err)
+		}
+		t.Logf("transient create error (attempt %d/%d), retrying with fresh name: %s", attempt, maxAttempts, err)
+	}
+
+	e2eAssertNoDrift(t, tf, ctx, envName, "create")
+
+	test := func() error {
+		WriteE2EConfig(t, workdir, configFn(envName, 3))
+		return tf.Apply(ctx)
+	}
+	if err := e2eRetryTransient(t, maxAttempts, test); err != nil {
+		t.Fatalf("update apply failed: %s", err)
+	}
+	e2eAssertNoDrift(t, tf, ctx, envName, "update")
+
+	t.Logf("e2e create+update+drift OK for %s (delete skipped: dev requires MFA)", envName)
+}
+
+func e2eAssertNoDrift(t *testing.T, tf *tfexec.Terraform, ctx context.Context, envName, phase string) {
+	t.Helper()
+	var changed bool
+	err := e2eRetryTransient(t, 3, func() error {
+		var planErr error
+		changed, planErr = tf.Plan(ctx)
+		return planErr
+	})
+	if err != nil {
+		t.Fatalf("plan after %s failed: %s", phase, err)
+	}
+	if changed {
+		t.Fatalf("unexpected drift after %s for env %s", phase, envName)
+	}
+}
+
+func e2eRetryTransient(t *testing.T, attempts int, fn func() error) error {
+	t.Helper()
+	var err error
+	for i := 1; i <= attempts; i++ {
+		err = fn()
+		if err == nil || !isE2ETransient(err) {
+			return err
+		}
+		t.Logf("transient error (attempt %d/%d): %s", i, attempts, err)
+	}
+	return err
 }
 
 // WriteE2EConfig writes main.tf (terraform block + given resource HCL) into the

--- a/internal/provider/test/e2e.go
+++ b/internal/provider/test/e2e.go
@@ -89,6 +89,10 @@ var e2eTransientPatterns = []string{
 	"EOF",
 	"request failed",
 	"502", "503", "504",
+	// Eventual consistency: a just-created env can briefly read as not found on
+	// the update that immediately follows (create lands on one backend, the
+	// update hits another). The update is idempotent (REPLACE), so retry.
+	"environment not found",
 }
 
 func isE2ETransient(err error) bool {

--- a/internal/provider/test/e2e.go
+++ b/internal/provider/test/e2e.go
@@ -1,0 +1,94 @@
+//go:build e2e
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// E2EAPIURL is the dev control plane the e2e tests talk to. Envs are created
+// with a "dummy-" name prefix, which the dev control plane treats as a sandbox
+// (no real cloud provisioning).
+const E2EAPIURL = "https://anywhere.dev.altinity.cloud"
+
+const e2eProviderSource = "altinity/altinitycloud"
+
+// E2EPreCheck skips the test when no API token is available (local runs, or PRs
+// from forks where the secret is not exposed).
+func E2EPreCheck(t *testing.T) {
+	t.Helper()
+	if os.Getenv("ALTINITYCLOUD_API_TOKEN") == "" {
+		t.Skip("ALTINITYCLOUD_API_TOKEN not set; skipping e2e tests against dev control plane")
+	}
+}
+
+// NewE2ETerraform builds the provider, wires a dev_overrides CLI config so a
+// real Terraform binary uses that local build (no init/registry), points the
+// provider at the dev control plane, and returns a tfexec handle plus its
+// working directory.
+//
+// These tests drive Terraform directly instead of using the plugin-testing
+// harness because that harness always runs a post-test destroy, and deleting an
+// env on the dev control plane requires MFA confirmation that CI cannot provide.
+// We therefore exercise create/update/drift and intentionally skip teardown;
+// dummy-prefixed envs are cleaned up out of band.
+func NewE2ETerraform(t *testing.T) (*tfexec.Terraform, string) {
+	t.Helper()
+
+	tfPath, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skip("terraform binary not found in PATH; skipping e2e tests")
+	}
+
+	pluginDir := t.TempDir()
+	bin := filepath.Join(pluginDir, "terraform-provider-altinitycloud")
+	if out, err := exec.Command("go", "build", "-o", bin, "github.com/altinity/terraform-provider-altinitycloud").CombinedOutput(); err != nil {
+		t.Fatalf("failed to build provider: %s\n%s", err, out)
+	}
+
+	cliConfig := filepath.Join(t.TempDir(), "dev.tfrc")
+	cliBody := fmt.Sprintf(`provider_installation {
+  dev_overrides {
+    %q = %q
+  }
+  direct {}
+}
+`, e2eProviderSource, pluginDir)
+	if err := os.WriteFile(cliConfig, []byte(cliBody), 0o600); err != nil {
+		t.Fatalf("failed to write CLI config: %s", err)
+	}
+
+	t.Setenv("TF_CLI_CONFIG_FILE", cliConfig)
+	t.Setenv("ALTINITYCLOUD_API_URL", E2EAPIURL)
+
+	workdir := t.TempDir()
+	tf, err := tfexec.NewTerraform(workdir, tfPath)
+	if err != nil {
+		t.Fatalf("failed to init tfexec: %s", err)
+	}
+	return tf, workdir
+}
+
+// WriteE2EConfig writes main.tf (terraform block + given resource HCL) into the
+// working directory.
+func WriteE2EConfig(t *testing.T, workdir, resourceHCL string) {
+	t.Helper()
+	hcl := `terraform {
+  required_providers {
+    altinitycloud = {
+      source = "` + e2eProviderSource + `"
+    }
+  }
+}
+
+` + resourceHCL
+	if err := os.WriteFile(filepath.Join(workdir, "main.tf"), []byte(hcl), 0o600); err != nil {
+		t.Fatalf("failed to write main.tf: %s", err)
+	}
+}

--- a/internal/provider/test/e2e.go
+++ b/internal/provider/test/e2e.go
@@ -104,6 +104,14 @@ func isE2ETransient(err error) bool {
 	return false
 }
 
+// isE2EAlreadyExists reports a name collision. The dev control plane can commit
+// an env server-side and still surface the create as a failure (e.g. it resets
+// a heavy create connection after committing), so a later attempt with the same
+// name collides. Retrying with a fresh name recovers, same as a transient error.
+func isE2EAlreadyExists(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "already exists")
+}
+
 // RunE2ELifecycle drives the standard env lifecycle against the dev control
 // plane: create -> drift check -> update -> drift check. Teardown is skipped
 // (dev delete requires MFA). configFn renders the resource HCL for a given env
@@ -128,10 +136,11 @@ func RunE2ELifecycle(t *testing.T, namePrefix string, configFn func(envName stri
 		if err == nil {
 			break
 		}
-		if attempt >= maxAttempts || !isE2ETransient(err) {
+		retryable := isE2ETransient(err) || isE2EAlreadyExists(err)
+		if attempt >= maxAttempts || !retryable {
 			t.Fatalf("create apply failed: %s", err)
 		}
-		t.Logf("transient create error (attempt %d/%d), retrying with fresh name: %s", attempt, maxAttempts, err)
+		t.Logf("retryable create error (attempt %d/%d), retrying with fresh name: %s", attempt, maxAttempts, err)
 	}
 
 	e2eAssertNoDrift(t, tf, ctx, envName, "create")

--- a/internal/provider/test/e2e.go
+++ b/internal/provider/test/e2e.go
@@ -3,13 +3,17 @@
 package test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
 )
@@ -28,6 +32,66 @@ func E2EPreCheck(t *testing.T) {
 	if os.Getenv("ALTINITYCLOUD_API_TOKEN") == "" {
 		t.Skip("ALTINITYCLOUD_API_TOKEN not set; skipping e2e tests against dev control plane")
 	}
+}
+
+// e2eReadyTimeout bounds how long to wait for the control plane to become
+// reachable; e2eReadyInterval is the gap between probes.
+const (
+	e2eReadyTimeout  = 3 * time.Minute
+	e2eReadyInterval = 10 * time.Second
+)
+
+// E2EWaitForAPI blocks until the control plane answers a trivial authenticated
+// GraphQL query, then returns. While the dev control plane is mid-deployment it
+// transiently rejects requests (e.g. "invalid API token", 5xx, reset
+// connections); waiting avoids spurious test failures during a deploy window.
+// If it never comes up within the timeout the test is skipped, not failed, so a
+// deploy in progress doesn't red the build.
+func E2EWaitForAPI(t *testing.T) {
+	t.Helper()
+	token := os.Getenv("ALTINITYCLOUD_API_TOKEN")
+	url := E2EAPIURL + "/api/v1/graphql"
+
+	deadline := time.Now().Add(e2eReadyTimeout)
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		if lastErr = e2ePingAPI(url, token); lastErr == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Skipf("control plane not ready after %s (last error: %s); skipping (likely mid-deployment)", e2eReadyTimeout, lastErr)
+		}
+		t.Logf("control plane not ready (attempt %d): %s; retrying in %s", attempt, lastErr, e2eReadyInterval)
+		time.Sleep(e2eReadyInterval)
+	}
+}
+
+// e2ePingAPI returns nil when an authenticated `{ __typename }` query succeeds.
+func e2ePingAPI(url, token string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), e2eReadyInterval)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(`{"query":"query { __typename }"}`))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); resp.Body.Close() }()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d: %s", resp.StatusCode, bytes.TrimSpace(body))
+	}
+	if !bytes.Contains(body, []byte("__typename")) {
+		return fmt.Errorf("unexpected response: %s", bytes.TrimSpace(body))
+	}
+	return nil
 }
 
 // NewE2ETerraform builds the provider, wires a dev_overrides CLI config so a
@@ -127,6 +191,7 @@ func isE2EAlreadyExists(err error) bool {
 func RunE2ELifecycle(t *testing.T, namePrefix string, configFn func(envName string, capacity int) string) {
 	t.Helper()
 	E2EPreCheck(t)
+	E2EWaitForAPI(t)
 	tf, workdir := NewE2ETerraform(t)
 	ctx := context.Background()
 

--- a/internal/sdk/client/client.go
+++ b/internal/sdk/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,15 +27,21 @@ func WithUserAgent(ctx context.Context, userAgent string) clientv2.RequestInterc
 	}
 }
 
-// retryablePatterns contains error substrings that indicate a transient failure.
-var retryablePatterns = []string{
-	"429",
-	"502",
-	"503",
-	"504",
+// retryableNetworkCodes are HTTP status codes that indicate a transient
+// server-side failure worth retrying.
+var retryableNetworkCodes = map[int]bool{
+	429: true,
+	502: true,
+	503: true,
+	504: true,
+}
+
+// transportPatterns match transport-level errors (no HTTP response received),
+// which clientv2 surfaces as a plain wrapped error rather than an
+// *ErrorResponse, so there is no status code to inspect.
+var transportPatterns = []string{
 	"connection reset",
 	"connection refused",
-	"connect: connection refused",
 	"i/o timeout",
 	"TLS handshake timeout",
 	"EOF",
@@ -44,8 +51,18 @@ func isRetryable(err error) bool {
 	if err == nil {
 		return false
 	}
+
+	// HTTP response received: only retry on transient status codes. GraphQL
+	// business errors (NetworkError nil) must never be retried, even if their
+	// message text happens to contain a code or "EOF".
+	var errResp *clientv2.ErrorResponse
+	if errors.As(err, &errResp) {
+		return errResp.NetworkError != nil && retryableNetworkCodes[errResp.NetworkError.Code]
+	}
+
+	// No HTTP response: classify the transport error by its message.
 	msg := err.Error()
-	for _, pattern := range retryablePatterns {
+	for _, pattern := range transportPatterns {
 		if strings.Contains(msg, pattern) {
 			return true
 		}
@@ -58,10 +75,29 @@ func isRetryable(err error) bool {
 // a transient error happens after the server committed it) yields spurious
 // failures like "environment already exists".
 func isMutation(gqlInfo *clientv2.GQLRequestInfo) bool {
+	// Fail closed: if the operation can't be determined, treat it as a mutation
+	// so it is never retried.
 	if gqlInfo == nil || gqlInfo.Request == nil {
-		return false
+		return true
 	}
-	return strings.HasPrefix(strings.TrimSpace(gqlInfo.Request.Query), "mutation")
+	return strings.HasPrefix(operationStart(gqlInfo.Request.Query), "mutation")
+}
+
+// operationStart returns the query with leading whitespace and '#' comment
+// lines stripped, so the operation keyword can be matched even when the query
+// begins with comments.
+func operationStart(query string) string {
+	for {
+		query = strings.TrimLeft(query, " \t\r\n")
+		if !strings.HasPrefix(query, "#") {
+			return query
+		}
+		i := strings.IndexByte(query, '\n')
+		if i < 0 {
+			return ""
+		}
+		query = query[i+1:]
+	}
 }
 
 func WithRetry(maxRetries int, initialBackoff time.Duration) clientv2.RequestInterceptor {

--- a/internal/sdk/client/client.go
+++ b/internal/sdk/client/client.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -53,10 +55,32 @@ func isRetryable(err error) bool {
 
 func WithRetry(maxRetries int, initialBackoff time.Duration) clientv2.RequestInterceptor {
 	return func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}, next clientv2.RequestInterceptorFunc) error {
+		// Buffer the body so it can be replayed: the transport consumes req.Body on
+		// each attempt, so without a fresh body a retry sends an empty payload
+		// ("ContentLength=N with Body length 0").
+		if req.Body != nil && req.GetBody == nil {
+			body, readErr := io.ReadAll(req.Body)
+			_ = req.Body.Close()
+			if readErr != nil {
+				return readErr
+			}
+			req.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(body)), nil
+			}
+		}
+
 		var err error
 		backoff := initialBackoff
 
 		for attempt := 0; attempt <= maxRetries; attempt++ {
+			if req.GetBody != nil {
+				body, bodyErr := req.GetBody()
+				if bodyErr != nil {
+					return bodyErr
+				}
+				req.Body = body
+			}
+
 			err = next(ctx, req, gqlInfo, res)
 			if err == nil {
 				return nil

--- a/internal/sdk/client/client.go
+++ b/internal/sdk/client/client.go
@@ -53,8 +53,24 @@ func isRetryable(err error) bool {
 	return false
 }
 
+// isMutation reports whether the GraphQL operation mutates server state. Such
+// operations are not idempotent: retrying one that already succeeded (e.g. when
+// a transient error happens after the server committed it) yields spurious
+// failures like "environment already exists".
+func isMutation(gqlInfo *clientv2.GQLRequestInfo) bool {
+	if gqlInfo == nil || gqlInfo.Request == nil {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(gqlInfo.Request.Query), "mutation")
+}
+
 func WithRetry(maxRetries int, initialBackoff time.Duration) clientv2.RequestInterceptor {
 	return func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}, next clientv2.RequestInterceptorFunc) error {
+		// Only idempotent operations (queries) are safe to retry.
+		if isMutation(gqlInfo) {
+			return next(ctx, req, gqlInfo, res)
+		}
+
 		// Buffer the body so it can be replayed: the transport consumes req.Body on
 		// each attempt, so without a fresh body a retry sends an empty payload
 		// ("ContentLength=N with Body length 0").

--- a/internal/sdk/client/client_test.go
+++ b/internal/sdk/client/client_test.go
@@ -157,6 +157,44 @@ func TestWithRetry_ReplaysBodyOnRetry(t *testing.T) {
 	}
 }
 
+func TestWithRetry_DoesNotRetryMutations(t *testing.T) {
+	interceptor := WithRetry(3, time.Millisecond)
+	calls := 0
+	next := func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}) error {
+		calls++
+		return errors.New("status 503")
+	}
+
+	gqlInfo := &clientv2.GQLRequestInfo{Request: &clientv2.Request{Query: "mutation CreateAWSEnv ($input: CreateAWSEnvInput!) { createAWSEnv }"}}
+	err := interceptor(context.Background(), &http.Request{}, gqlInfo, nil, next)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (mutations are not retried), got %d", calls)
+	}
+}
+
+func TestWithRetry_RetriesQueries(t *testing.T) {
+	interceptor := WithRetry(3, time.Millisecond)
+	calls := 0
+	next := func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}) error {
+		calls++
+		if calls < 2 {
+			return errors.New("status 503")
+		}
+		return nil
+	}
+
+	gqlInfo := &clientv2.GQLRequestInfo{Request: &clientv2.Request{Query: "query GetAWSEnv ($name: String!) { awsEnv }"}}
+	if err := interceptor(context.Background(), &http.Request{}, gqlInfo, nil, next); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls (queries are retried), got %d", calls)
+	}
+}
+
 func TestIsRetryable(t *testing.T) {
 	tests := []struct {
 		err  string

--- a/internal/sdk/client/client_test.go
+++ b/internal/sdk/client/client_test.go
@@ -10,7 +10,25 @@ import (
 	"time"
 
 	"github.com/Yamashou/gqlgenc/clientv2"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
+
+// netErr builds the *clientv2.ErrorResponse the client returns for a non-2xx
+// HTTP response (a transient, server-side failure).
+func netErr(code int) error {
+	return &clientv2.ErrorResponse{NetworkError: &clientv2.HTTPError{Code: code, Message: "boom"}}
+}
+
+// gqlErr builds the *clientv2.ErrorResponse the client returns for a 200 OK
+// response that carries GraphQL business errors (no network error).
+func gqlErr(message string) error {
+	return &clientv2.ErrorResponse{GqlErrors: &gqlerror.List{{Message: message}}}
+}
+
+// queryInfo is a retryable (non-mutation) operation for exercising WithRetry.
+func queryInfo() *clientv2.GQLRequestInfo {
+	return &clientv2.GQLRequestInfo{Request: &clientv2.Request{Query: "query GetAWSEnv { awsEnv }"}}
+}
 
 func TestWithRetry_Success(t *testing.T) {
 	interceptor := WithRetry(3, time.Millisecond)
@@ -35,12 +53,12 @@ func TestWithRetry_RetryableSucceedsOnThird(t *testing.T) {
 	next := func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}) error {
 		calls++
 		if calls < 3 {
-			return errors.New("status 503")
+			return netErr(503)
 		}
 		return nil
 	}
 
-	err := interceptor(context.Background(), &http.Request{}, &clientv2.GQLRequestInfo{}, nil, next)
+	err := interceptor(context.Background(), &http.Request{}, queryInfo(), nil, next)
 	if err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
 	}
@@ -54,10 +72,10 @@ func TestWithRetry_NonRetryableError(t *testing.T) {
 	calls := 0
 	next := func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}) error {
 		calls++
-		return errors.New("status 400 bad request")
+		return netErr(400)
 	}
 
-	err := interceptor(context.Background(), &http.Request{}, &clientv2.GQLRequestInfo{}, nil, next)
+	err := interceptor(context.Background(), &http.Request{}, queryInfo(), nil, next)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -74,7 +92,7 @@ func TestWithRetry_ExhaustsRetries(t *testing.T) {
 		return errors.New("connection refused")
 	}
 
-	err := interceptor(context.Background(), &http.Request{}, &clientv2.GQLRequestInfo{}, nil, next)
+	err := interceptor(context.Background(), &http.Request{}, queryInfo(), nil, next)
 	if err == nil {
 		t.Fatal("expected error after retries exhausted")
 	}
@@ -91,10 +109,10 @@ func TestWithRetry_RespectsContextCancellation(t *testing.T) {
 	next := func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}) error {
 		calls++
 		cancel()
-		return errors.New("status 503")
+		return netErr(503)
 	}
 
-	err := interceptor(ctx, &http.Request{}, &clientv2.GQLRequestInfo{}, nil, next)
+	err := interceptor(ctx, &http.Request{}, queryInfo(), nil, next)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got: %v", err)
 	}
@@ -109,12 +127,12 @@ func TestWithRetry_429IsRetryable(t *testing.T) {
 	next := func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}) error {
 		calls++
 		if calls == 1 {
-			return errors.New("status 429 too many requests")
+			return netErr(429)
 		}
 		return nil
 	}
 
-	err := interceptor(context.Background(), &http.Request{}, &clientv2.GQLRequestInfo{}, nil, next)
+	err := interceptor(context.Background(), &http.Request{}, queryInfo(), nil, next)
 	if err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
 	}
@@ -139,12 +157,12 @@ func TestWithRetry_ReplaysBodyOnRetry(t *testing.T) {
 		body, _ := io.ReadAll(req.Body)
 		reads = append(reads, string(body))
 		if calls < 3 {
-			return errors.New("status 503")
+			return netErr(503)
 		}
 		return nil
 	}
 
-	if err := interceptor(context.Background(), req, &clientv2.GQLRequestInfo{}, nil, next); err != nil {
+	if err := interceptor(context.Background(), req, queryInfo(), nil, next); err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
 	}
 	if calls != 3 {
@@ -162,7 +180,7 @@ func TestWithRetry_DoesNotRetryMutations(t *testing.T) {
 	calls := 0
 	next := func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}) error {
 		calls++
-		return errors.New("status 503")
+		return netErr(503)
 	}
 
 	gqlInfo := &clientv2.GQLRequestInfo{Request: &clientv2.Request{Query: "mutation CreateAWSEnv ($input: CreateAWSEnvInput!) { createAWSEnv }"}}
@@ -175,13 +193,31 @@ func TestWithRetry_DoesNotRetryMutations(t *testing.T) {
 	}
 }
 
+func TestWithRetry_DoesNotRetryCommentedMutation(t *testing.T) {
+	interceptor := WithRetry(3, time.Millisecond)
+	calls := 0
+	next := func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}) error {
+		calls++
+		return netErr(503)
+	}
+
+	gqlInfo := &clientv2.GQLRequestInfo{Request: &clientv2.Request{Query: "# leading comment\n\nmutation CreateAWSEnv { createAWSEnv }"}}
+	err := interceptor(context.Background(), &http.Request{}, gqlInfo, nil, next)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (commented mutation must not be retried), got %d", calls)
+	}
+}
+
 func TestWithRetry_RetriesQueries(t *testing.T) {
 	interceptor := WithRetry(3, time.Millisecond)
 	calls := 0
 	next := func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}) error {
 		calls++
 		if calls < 2 {
-			return errors.New("status 503")
+			return netErr(503)
 		}
 		return nil
 	}
@@ -197,29 +233,58 @@ func TestWithRetry_RetriesQueries(t *testing.T) {
 
 func TestIsRetryable(t *testing.T) {
 	tests := []struct {
-		err  string
+		name string
+		err  error
 		want bool
 	}{
-		{"status 429", true},
-		{"status 502", true},
-		{"status 503", true},
-		{"status 504", true},
-		{"connection reset", true},
-		{"connection refused", true},
-		{"i/o timeout", true},
-		{"TLS handshake timeout", true},
-		{"EOF", true},
-		{"status 400", false},
-		{"status 401", false},
-		{"status 403", false},
-		{"status 404", false},
-		{"some random error", false},
+		{"429 network", netErr(429), true},
+		{"502 network", netErr(502), true},
+		{"503 network", netErr(503), true},
+		{"504 network", netErr(504), true},
+		{"400 network", netErr(400), false},
+		{"401 network", netErr(401), false},
+		{"404 network", netErr(404), false},
+		{"connection reset", errors.New("connection reset by peer"), true},
+		{"connection refused", errors.New("connection refused"), true},
+		{"i/o timeout", errors.New("dial tcp: i/o timeout"), true},
+		{"TLS handshake timeout", errors.New("net/http: TLS handshake timeout"), true},
+		{"EOF transport", errors.New("request failed: EOF"), true},
+		{"random transport", errors.New("some random error"), false},
+		// GraphQL business errors must never be retried, even when the message
+		// text happens to contain a transient code or "EOF".
+		{"gql error mentioning 503", gqlErr("validation failed: value 503 invalid"), false},
+		{"gql error mentioning EOF", gqlErr("unexpected EOF in user input"), false},
 	}
 
 	for _, tt := range tests {
-		got := isRetryable(errors.New(tt.err))
-		if got != tt.want {
-			t.Errorf("isRetryable(%q) = %v, want %v", tt.err, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryable(tt.err); got != tt.want {
+				t.Errorf("isRetryable(%q) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMutation(t *testing.T) {
+	tests := []struct {
+		name    string
+		gqlInfo *clientv2.GQLRequestInfo
+		want    bool
+	}{
+		{"plain mutation", &clientv2.GQLRequestInfo{Request: &clientv2.Request{Query: "mutation Foo { foo }"}}, true},
+		{"leading whitespace mutation", &clientv2.GQLRequestInfo{Request: &clientv2.Request{Query: "\n\t  mutation Foo { foo }"}}, true},
+		{"commented mutation", &clientv2.GQLRequestInfo{Request: &clientv2.Request{Query: "# c1\n# c2\nmutation Foo { foo }"}}, true},
+		{"query", &clientv2.GQLRequestInfo{Request: &clientv2.Request{Query: "query Foo { foo }"}}, false},
+		{"commented query", &clientv2.GQLRequestInfo{Request: &clientv2.Request{Query: "# note\nquery Foo { foo }"}}, false},
+		{"nil info fails closed", nil, true},
+		{"nil request fails closed", &clientv2.GQLRequestInfo{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMutation(tt.gqlInfo); got != tt.want {
+				t.Errorf("isMutation() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/sdk/client/client_test.go
+++ b/internal/sdk/client/client_test.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -118,6 +120,40 @@ func TestWithRetry_429IsRetryable(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Errorf("expected 2 calls, got %d", calls)
+	}
+}
+
+func TestWithRetry_ReplaysBodyOnRetry(t *testing.T) {
+	interceptor := WithRetry(3, time.Millisecond)
+	const payload = "graphql-payload"
+
+	req, err := http.NewRequest(http.MethodPost, "http://example.test", bytes.NewReader([]byte(payload)))
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	calls := 0
+	var reads []string
+	next := func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}) error {
+		calls++
+		body, _ := io.ReadAll(req.Body)
+		reads = append(reads, string(body))
+		if calls < 3 {
+			return errors.New("status 503")
+		}
+		return nil
+	}
+
+	if err := interceptor(context.Background(), req, &clientv2.GQLRequestInfo{}, nil, next); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+	for i, got := range reads {
+		if got != payload {
+			t.Errorf("attempt %d read body %q, want %q (body not replayed on retry)", i+1, got, payload)
+		}
 	}
 }
 

--- a/internal/sdk/client/errors.go
+++ b/internal/sdk/client/errors.go
@@ -8,7 +8,7 @@ import (
 
 type GraphQLError struct {
 	Message    string                 `json:"message"`
-	Path       []string               `json:"path"`
+	Path       []interface{}          `json:"path"` // GraphQL path elements are strings or list indices (ints)
 	Extensions map[string]interface{} `json:"extensions"`
 }
 
@@ -122,7 +122,11 @@ func errorPrefix(gqlError GraphQLError) string {
 
 	// No extension code: infer from mutation path (create/update/delete).
 	for _, p := range gqlError.Path {
-		lp := strings.ToLower(p)
+		s, ok := p.(string)
+		if !ok {
+			continue
+		}
+		lp := strings.ToLower(s)
 		if strings.HasPrefix(lp, "create") || strings.HasPrefix(lp, "update") || strings.HasPrefix(lp, "delete") {
 			return "Validation Error"
 		}


### PR DESCRIPTION

E2E tests that drive create/update + drift against the real dev control plane (`https://anywhere.dev.altinity.cloud`) using `dummy-`-prefixed envs (dev treats them as a sandbox — no real cloud provisioning).

A `tfexec` harness drives Terraform directly instead of `resource.Test`: that harness always runs a post-test destroy, and deleting an env on dev requires MFA, which CI can't confirm. So delete is skipped; dummy envs are cleaned up out of band.

#### Coverage
```
apply(create) → plan (assert no drift) → apply(update) → plan (assert no drift)
```

#### CI
New `e2e` job runs on every PR/push, installs Terraform, token from `secrets.ALTINITYCLOUD_DEV_API_TOKEN`. Skips when the secret is absent (fork PRs) or no `terraform` on PATH.

#### Run locally
```
ALTINITYCLOUD_API_TOKEN=<dev-token> make test-e2e
```