### PR TITLE
fix: preserve config order of zones inside node groups

### DIFF
--- a/internal/provider/env/aws/model.go
+++ b/internal/provider/env/aws/model.go
@@ -442,6 +442,15 @@ func nodeGroupsToSDK(ctx context.Context, nodeGroups []common.NodeGroupsModel) (
 	return sdkNodeGroups, allDiags
 }
 
+func reorderNodeGroupZones(ctx context.Context, model []common.NodeGroupsModel, items []*sdk.AWSEnvSpecFragment_NodeGroups) diag.Diagnostics {
+	return common.ReorderNodeGroupZones(ctx, model, items,
+		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
+		func(s *sdk.AWSEnvSpecFragment_NodeGroups) string { return s.NodeType },
+		func(m common.NodeGroupsModel) types.List { return m.Zones },
+		func(s *sdk.AWSEnvSpecFragment_NodeGroups) *[]string { return &s.Zones },
+	)
+}
+
 func nodeGroupsToModel(nodeGroups []*sdk.AWSEnvSpecFragment_NodeGroups) ([]common.NodeGroupsModel, diag.Diagnostics) {
 	var allDiags diag.Diagnostics
 	var modelNodeGroups []common.NodeGroupsModel

--- a/internal/provider/env/aws/model_test.go
+++ b/internal/provider/env/aws/model_test.go
@@ -163,6 +163,32 @@ func TestReorderNodeGroups(t *testing.T) {
 	}
 }
 
+func TestReorderNodeGroupZones(t *testing.T) {
+	configZones := types.ListValueMust(types.StringType, []attr.Value{
+		types.StringValue("us-east-1d"),
+		types.StringValue("us-east-1a"),
+	})
+	model := []common.NodeGroupsModel{
+		{NodeType: types.StringValue("system"), Zones: configZones},
+		{NodeType: types.StringValue("user"), Zones: configZones},
+	}
+	api := []*sdk.AWSEnvSpecFragment_NodeGroups{
+		{NodeType: "system", Zones: []string{"us-east-1a", "us-east-1d"}},
+		{NodeType: "user", Zones: []string{"us-east-1a", "us-east-1d"}},
+	}
+
+	diags := reorderNodeGroupZones(context.Background(), model, api)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	for i, group := range api {
+		if group.Zones[0] != "us-east-1d" || group.Zones[1] != "us-east-1a" {
+			t.Errorf("node group %d: expected zones [us-east-1d us-east-1a], got %v", i, group.Zones)
+		}
+	}
+}
+
 func TestMaintenanceWindowsToModel(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/provider/env/aws/resource.go
+++ b/internal/provider/env/aws/resource.go
@@ -75,6 +75,7 @@ func (r *AWSEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.AWSEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupZones(ctx, data.NodeGroups, apiResp.CreateAWSEnv.Spec.NodeGroups)...)
 	apiResp.CreateAWSEnv.Spec.Zones, diags = common.ReorderList(ctx, data.Zones, apiResp.CreateAWSEnv.Spec.Zones)
 	resp.Diagnostics.Append(diags...)
 	apiResp.CreateAWSEnv.Spec.Tags = common.ReorderByKey(data.Tags, apiResp.CreateAWSEnv.Spec.Tags,
@@ -130,6 +131,7 @@ func (r *AWSEnvResource) Read(ctx context.Context, req resource.ReadRequest, res
 		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.AWSEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupZones(ctx, data.NodeGroups, apiResp.AWSEnv.Spec.NodeGroups)...)
 	apiResp.AWSEnv.Spec.Zones, diags = common.ReorderList(ctx, data.Zones, apiResp.AWSEnv.Spec.Zones)
 	resp.Diagnostics.Append(diags...)
 	apiResp.AWSEnv.Spec.Tags = common.ReorderByKey(data.Tags, apiResp.AWSEnv.Spec.Tags,
@@ -180,6 +182,7 @@ func (r *AWSEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.AWSEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupZones(ctx, data.NodeGroups, apiResp.UpdateAWSEnv.Spec.NodeGroups)...)
 	apiResp.UpdateAWSEnv.Spec.Zones, diags = common.ReorderList(ctx, data.Zones, apiResp.UpdateAWSEnv.Spec.Zones)
 	resp.Diagnostics.Append(diags...)
 	apiResp.UpdateAWSEnv.Spec.Tags = common.ReorderByKey(data.Tags, apiResp.UpdateAWSEnv.Spec.Tags,

--- a/internal/provider/env/azure/model.go
+++ b/internal/provider/env/azure/model.go
@@ -277,6 +277,15 @@ func nodeGroupsToSDK(ctx context.Context, nodeGroups []common.NodeGroupsModel) (
 	return sdkNodeGroups, allDiags
 }
 
+func reorderNodeGroupZones(ctx context.Context, model []common.NodeGroupsModel, items []*client.AzureEnvSpecFragment_NodeGroups) diag.Diagnostics {
+	return common.ReorderNodeGroupZones(ctx, model, items,
+		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
+		func(s *client.AzureEnvSpecFragment_NodeGroups) string { return s.NodeType },
+		func(m common.NodeGroupsModel) types.List { return m.Zones },
+		func(s *client.AzureEnvSpecFragment_NodeGroups) *[]string { return &s.Zones },
+	)
+}
+
 func nodeGroupsToModel(nodeGroups []*client.AzureEnvSpecFragment_NodeGroups) ([]common.NodeGroupsModel, diag.Diagnostics) {
 	var allDiags diag.Diagnostics
 	var modelNodeGroups []common.NodeGroupsModel

--- a/internal/provider/env/azure/resource.go
+++ b/internal/provider/env/azure/resource.go
@@ -76,6 +76,7 @@ func (r *AzureEnvResource) Create(ctx context.Context, req resource.CreateReques
 		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.AzureEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupZones(ctx, data.NodeGroups, apiResp.CreateAzureEnv.Spec.NodeGroups)...)
 	apiResp.CreateAzureEnv.Spec.Zones, diags = common.ReorderList(ctx, data.Zones, apiResp.CreateAzureEnv.Spec.Zones)
 	resp.Diagnostics.Append(diags...)
 	apiResp.CreateAzureEnv.Spec.Tags = common.ReorderByKey(data.Tags, apiResp.CreateAzureEnv.Spec.Tags,
@@ -127,6 +128,7 @@ func (r *AzureEnvResource) Read(ctx context.Context, req resource.ReadRequest, r
 		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.AzureEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupZones(ctx, data.NodeGroups, apiResp.AzureEnv.Spec.NodeGroups)...)
 	apiResp.AzureEnv.Spec.Zones, diags = common.ReorderList(ctx, data.Zones, apiResp.AzureEnv.Spec.Zones)
 	resp.Diagnostics.Append(diags...)
 	apiResp.AzureEnv.Spec.Tags = common.ReorderByKey(data.Tags, apiResp.AzureEnv.Spec.Tags,
@@ -173,6 +175,7 @@ func (r *AzureEnvResource) Update(ctx context.Context, req resource.UpdateReques
 		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.AzureEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupZones(ctx, data.NodeGroups, apiResp.UpdateAzureEnv.Spec.NodeGroups)...)
 	apiResp.UpdateAzureEnv.Spec.Zones, diags = common.ReorderList(ctx, data.Zones, apiResp.UpdateAzureEnv.Spec.Zones)
 	resp.Diagnostics.Append(diags...)
 	apiResp.UpdateAzureEnv.Spec.Tags = common.ReorderByKey(data.Tags, apiResp.UpdateAzureEnv.Spec.Tags,

--- a/internal/provider/env/common/model.go
+++ b/internal/provider/env/common/model.go
@@ -67,6 +67,38 @@ func ReorderByKey[M any, S any](model []M, items []S, getModelKey func(M) string
 	return ordered
 }
 
+// Pairing mirrors ReorderByKey so both resolve the same model/item pairs; mutates items via itemList.
+func ReorderNodeGroupZones[M any, S any](
+	ctx context.Context,
+	model []M,
+	items []S,
+	getModelKey func(M) string,
+	getItemKey func(S) string,
+	modelList func(M) types.List,
+	itemList func(S) *[]string,
+) diag.Diagnostics {
+	var allDiags diag.Diagnostics
+	used := make([]bool, len(items))
+
+	for _, m := range model {
+		mk := getModelKey(m)
+		for i, item := range items {
+			if !used[i] && mk == getItemKey(item) {
+				used[i] = true
+				target := itemList(item)
+				reordered, diags := ReorderList(ctx, modelList(m), *target)
+				allDiags.Append(diags...)
+				if !diags.HasError() {
+					*target = reordered
+				}
+				break
+			}
+		}
+	}
+
+	return allDiags
+}
+
 func ReorderList(ctx context.Context, model types.List, input []string) ([]string, diag.Diagnostics) {
 	if model.IsUnknown() || model.IsNull() {
 		return input, nil

--- a/internal/provider/env/common/model_test.go
+++ b/internal/provider/env/common/model_test.go
@@ -130,6 +130,103 @@ func TestReorderByKeyDuplicateKeys(t *testing.T) {
 	})
 }
 
+func TestReorderNodeGroupZones(t *testing.T) {
+	type modelNG struct {
+		NodeType string
+		Zones    types.List
+	}
+	type apiNG struct {
+		NodeType string
+		Zones    []string
+	}
+
+	zonesList := func(zones ...string) types.List {
+		values := make([]attr.Value, len(zones))
+		for i, z := range zones {
+			values[i] = types.StringValue(z)
+		}
+		return types.ListValueMust(types.StringType, values)
+	}
+
+	run := func(t *testing.T, model []modelNG, items []*apiNG) {
+		t.Helper()
+		diags := ReorderNodeGroupZones(context.Background(), model, items,
+			func(m modelNG) string { return m.NodeType },
+			func(s *apiNG) string { return s.NodeType },
+			func(m modelNG) types.List { return m.Zones },
+			func(s *apiNG) *[]string { return &s.Zones },
+		)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+	}
+
+	assertZones := func(t *testing.T, got, want []string) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("expected zones %v, got %v", want, got)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("expected zones %v, got %v", want, got)
+			}
+		}
+	}
+
+	t.Run("reorders zones to model order per node group", func(t *testing.T) {
+		model := []modelNG{
+			{NodeType: "system", Zones: zonesList("us-east-1d", "us-east-1a")},
+			{NodeType: "user", Zones: zonesList("us-east-1d", "us-east-1a")},
+		}
+		items := []*apiNG{
+			{NodeType: "system", Zones: []string{"us-east-1a", "us-east-1d"}},
+			{NodeType: "user", Zones: []string{"us-east-1a", "us-east-1d"}},
+		}
+		run(t, model, items)
+		assertZones(t, items[0].Zones, []string{"us-east-1d", "us-east-1a"})
+		assertZones(t, items[1].Zones, []string{"us-east-1d", "us-east-1a"})
+	})
+
+	t.Run("null model zones keep API order", func(t *testing.T) {
+		model := []modelNG{{NodeType: "system", Zones: types.ListNull(types.StringType)}}
+		items := []*apiNG{{NodeType: "system", Zones: []string{"us-east-1b", "us-east-1a"}}}
+		run(t, model, items)
+		assertZones(t, items[0].Zones, []string{"us-east-1b", "us-east-1a"})
+	})
+
+	t.Run("API-only node group untouched", func(t *testing.T) {
+		model := []modelNG{{NodeType: "system", Zones: zonesList("us-east-1b", "us-east-1a")}}
+		items := []*apiNG{
+			{NodeType: "system", Zones: []string{"us-east-1a", "us-east-1b"}},
+			{NodeType: "extra", Zones: []string{"us-east-1c", "us-east-1a"}},
+		}
+		run(t, model, items)
+		assertZones(t, items[0].Zones, []string{"us-east-1b", "us-east-1a"})
+		assertZones(t, items[1].Zones, []string{"us-east-1c", "us-east-1a"})
+	})
+
+	t.Run("duplicate node types pair positionally", func(t *testing.T) {
+		model := []modelNG{
+			{NodeType: "t4g.large", Zones: zonesList("us-east-1b", "us-east-1a")},
+			{NodeType: "t4g.large", Zones: zonesList("us-east-1d", "us-east-1c")},
+		}
+		items := []*apiNG{
+			{NodeType: "t4g.large", Zones: []string{"us-east-1a", "us-east-1b"}},
+			{NodeType: "t4g.large", Zones: []string{"us-east-1c", "us-east-1d"}},
+		}
+		run(t, model, items)
+		assertZones(t, items[0].Zones, []string{"us-east-1b", "us-east-1a"})
+		assertZones(t, items[1].Zones, []string{"us-east-1d", "us-east-1c"})
+	})
+
+	t.Run("extra API zones appended after model order", func(t *testing.T) {
+		model := []modelNG{{NodeType: "system", Zones: zonesList("us-east-1d", "us-east-1a")}}
+		items := []*apiNG{{NodeType: "system", Zones: []string{"us-east-1a", "us-east-1b", "us-east-1d"}}}
+		run(t, model, items)
+		assertZones(t, items[0].Zones, []string{"us-east-1d", "us-east-1a", "us-east-1b"})
+	})
+}
+
 func TestReorderList(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/provider/env/gcp/model.go
+++ b/internal/provider/env/gcp/model.go
@@ -296,6 +296,15 @@ func nodeGroupsToSDK(ctx context.Context, nodeGroups []common.NodeGroupsModel) (
 	return sdkNodeGroups, allDiags
 }
 
+func reorderNodeGroupZones(ctx context.Context, model []common.NodeGroupsModel, items []*sdk.GCPEnvSpecFragment_NodeGroups) diag.Diagnostics {
+	return common.ReorderNodeGroupZones(ctx, model, items,
+		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
+		func(s *sdk.GCPEnvSpecFragment_NodeGroups) string { return s.NodeType },
+		func(m common.NodeGroupsModel) types.List { return m.Zones },
+		func(s *sdk.GCPEnvSpecFragment_NodeGroups) *[]string { return &s.Zones },
+	)
+}
+
 func nodeGroupsToModel(nodeGroups []*sdk.GCPEnvSpecFragment_NodeGroups) ([]common.NodeGroupsModel, diag.Diagnostics) {
 	var allDiags diag.Diagnostics
 	var modelNodeGroups []common.NodeGroupsModel

--- a/internal/provider/env/gcp/resource.go
+++ b/internal/provider/env/gcp/resource.go
@@ -76,6 +76,7 @@ func (r *GCPEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.GCPEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupZones(ctx, data.NodeGroups, apiResp.CreateGCPEnv.Spec.NodeGroups)...)
 	apiResp.CreateGCPEnv.Spec.Zones, diags = common.ReorderList(ctx, data.Zones, apiResp.CreateGCPEnv.Spec.Zones)
 	resp.Diagnostics.Append(diags...)
 	apiResp.CreateGCPEnv.Spec.Labels = common.ReorderByKey(data.Labels, apiResp.CreateGCPEnv.Spec.Labels,
@@ -131,6 +132,7 @@ func (r *GCPEnvResource) Read(ctx context.Context, req resource.ReadRequest, res
 		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.GCPEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupZones(ctx, data.NodeGroups, apiResp.GCPEnv.Spec.NodeGroups)...)
 	apiResp.GCPEnv.Spec.Zones, diags = common.ReorderList(ctx, data.Zones, apiResp.GCPEnv.Spec.Zones)
 	resp.Diagnostics.Append(diags...)
 	apiResp.GCPEnv.Spec.Labels = common.ReorderByKey(data.Labels, apiResp.GCPEnv.Spec.Labels,
@@ -181,6 +183,7 @@ func (r *GCPEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 		func(m common.NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.GCPEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupZones(ctx, data.NodeGroups, apiResp.UpdateGCPEnv.Spec.NodeGroups)...)
 	apiResp.UpdateGCPEnv.Spec.Zones, diags = common.ReorderList(ctx, data.Zones, apiResp.UpdateGCPEnv.Spec.Zones)
 	resp.Diagnostics.Append(diags...)
 	apiResp.UpdateGCPEnv.Spec.Labels = common.ReorderByKey(data.Labels, apiResp.UpdateGCPEnv.Spec.Labels,

--- a/internal/provider/env/hcloud/model.go
+++ b/internal/provider/env/hcloud/model.go
@@ -279,6 +279,15 @@ func wireguardPeersToSDK(ctx context.Context, peers []WireguardPeers) ([]*client
 	return sdkPeers, allDiags
 }
 
+func reorderNodeGroupLocations(ctx context.Context, model []NodeGroupsModel, items []*client.HCloudEnvSpecFragment_NodeGroups) diag.Diagnostics {
+	return common.ReorderNodeGroupZones(ctx, model, items,
+		func(m NodeGroupsModel) string { return m.NodeType.ValueString() },
+		func(s *client.HCloudEnvSpecFragment_NodeGroups) string { return s.NodeType },
+		func(m NodeGroupsModel) types.List { return m.Locations },
+		func(s *client.HCloudEnvSpecFragment_NodeGroups) *[]string { return &s.Locations },
+	)
+}
+
 func nodeGroupsToModel(nodeGroups []*client.HCloudEnvSpecFragment_NodeGroups) ([]NodeGroupsModel, diag.Diagnostics) {
 	var allDiags diag.Diagnostics
 	var modelNodeGroups []NodeGroupsModel

--- a/internal/provider/env/hcloud/resource.go
+++ b/internal/provider/env/hcloud/resource.go
@@ -76,6 +76,7 @@ func (r *HCloudEnvResource) Create(ctx context.Context, req resource.CreateReque
 		func(m NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.HCloudEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupLocations(ctx, data.NodeGroups, apiResp.CreateHCloudEnv.Spec.NodeGroups)...)
 	apiResp.CreateHCloudEnv.Spec.Locations, diags = common.ReorderList(ctx, data.Locations, apiResp.CreateHCloudEnv.Spec.Locations)
 	resp.Diagnostics.Append(diags...)
 	data.Id = data.Name
@@ -123,6 +124,7 @@ func (r *HCloudEnvResource) Read(ctx context.Context, req resource.ReadRequest, 
 		func(m NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.HCloudEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupLocations(ctx, data.NodeGroups, apiResp.HcloudEnv.Spec.NodeGroups)...)
 	apiResp.HcloudEnv.Spec.Locations, diags = common.ReorderList(ctx, data.Locations, apiResp.HcloudEnv.Spec.Locations)
 	resp.Diagnostics.Append(diags...)
 	diags = data.toModel(*apiResp.HcloudEnv)
@@ -165,6 +167,7 @@ func (r *HCloudEnvResource) Update(ctx context.Context, req resource.UpdateReque
 		func(m NodeGroupsModel) string { return m.NodeType.ValueString() },
 		func(s *client.HCloudEnvSpecFragment_NodeGroups) string { return s.NodeType },
 	)
+	resp.Diagnostics.Append(reorderNodeGroupLocations(ctx, data.NodeGroups, apiResp.UpdateHCloudEnv.Spec.NodeGroups)...)
 	apiResp.UpdateHCloudEnv.Spec.Locations, diags = common.ReorderList(ctx, data.Locations, apiResp.UpdateHCloudEnv.Spec.Locations)
 	resp.Diagnostics.Append(diags...)
 	data.Locations, diags = common.ListToModel(apiResp.UpdateHCloudEnv.Spec.Locations)

--- a/internal/provider/env/k8s/model.go
+++ b/internal/provider/env/k8s/model.go
@@ -491,7 +491,8 @@ func tolerationKey(key, value, operator, effect string) string {
 	return key + "\x1f" + value + "\x1f" + operator + "\x1f" + effect
 }
 
-func reorderNodeGroups(model []NodeGroupsModel, items []*client.K8SEnvSpecFragment_NodeGroups) []*client.K8SEnvSpecFragment_NodeGroups {
+func reorderNodeGroups(ctx context.Context, model []NodeGroupsModel, items []*client.K8SEnvSpecFragment_NodeGroups) ([]*client.K8SEnvSpecFragment_NodeGroups, diag.Diagnostics) {
+	var allDiags diag.Diagnostics
 	ordered := make([]*client.K8SEnvSpecFragment_NodeGroups, 0, len(items))
 	used := make([]bool, len(items))
 
@@ -513,6 +514,11 @@ func reorderNodeGroups(model []NodeGroupsModel, items []*client.K8SEnvSpecFragme
 	for _, ng := range model {
 		for _, apiGroup := range ordered {
 			if nodeGroupMatches(ng, apiGroup) {
+				zones, diags := common.ReorderList(ctx, ng.Zones, apiGroup.Zones)
+				allDiags.Append(diags...)
+				if !diags.HasError() {
+					apiGroup.Zones = zones
+				}
 				apiGroup.Selector = common.ReorderByKey(ng.NodeSelector, apiGroup.Selector,
 					func(m common.KeyValueModel) string { return selectorKey(m.Key.ValueString(), m.Value.ValueString()) },
 					func(s *client.K8SEnvSpecFragment_NodeGroups_Selector) string { return selectorKey(s.Key, s.Value) },
@@ -530,5 +536,5 @@ func reorderNodeGroups(model []NodeGroupsModel, items []*client.K8SEnvSpecFragme
 		}
 	}
 
-	return ordered
+	return ordered, allDiags
 }

--- a/internal/provider/env/k8s/model_test.go
+++ b/internal/provider/env/k8s/model_test.go
@@ -109,7 +109,7 @@ func TestReorderNodeGroups(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := reorderNodeGroups(tt.model, tt.apiNodeGroups)
+			result, _ := reorderNodeGroups(context.Background(), tt.model, tt.apiNodeGroups)
 
 			if len(result) != tt.expectedLength {
 				t.Errorf("Expected length %d, got %d", tt.expectedLength, len(result))
@@ -175,7 +175,7 @@ func TestReorderNodeGroupsSameTypeDistinctNames(t *testing.T) {
 		{NodeType: "t4g.large", Name: "ng-b", CapacityPerZone: 2},
 	}
 
-	result := reorderNodeGroups(model, api)
+	result, _ := reorderNodeGroups(context.Background(), model, api)
 
 	if len(result) != 2 {
 		t.Fatalf("expected 2 node groups, got %d", len(result))
@@ -185,6 +185,30 @@ func TestReorderNodeGroupsSameTypeDistinctNames(t *testing.T) {
 	}
 	if result[0].CapacityPerZone != 2 || result[1].CapacityPerZone != 1 {
 		t.Errorf("capacity mispaired: got ng-b=%d ng-a=%d (want 2, 1)", result[0].CapacityPerZone, result[1].CapacityPerZone)
+	}
+}
+
+func TestReorderNodeGroupZones(t *testing.T) {
+	model := []NodeGroupsModel{
+		{
+			Name:     types.StringValue("ng"),
+			NodeType: types.StringValue("t4g.large"),
+			Zones: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("us-east-1d"),
+				types.StringValue("us-east-1a"),
+			}),
+		},
+	}
+	api := []*client.K8SEnvSpecFragment_NodeGroups{
+		{NodeType: "t4g.large", Name: "ng", Zones: []string{"us-east-1a", "us-east-1d"}},
+	}
+
+	result, diags := reorderNodeGroups(context.Background(), model, api)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if result[0].Zones[0] != "us-east-1d" || result[0].Zones[1] != "us-east-1a" {
+		t.Errorf("expected zones [us-east-1d us-east-1a], got %v", result[0].Zones)
 	}
 }
 

--- a/internal/provider/env/k8s/resource.go
+++ b/internal/provider/env/k8s/resource.go
@@ -53,7 +53,8 @@ func (r *K8SEnvResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Reorder node groups  and zones to respect order in the user's configuration
-	apiResp.CreateK8SEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.CreateK8SEnv.Spec.NodeGroups)
+	apiResp.CreateK8SEnv.Spec.NodeGroups, diags = reorderNodeGroups(ctx, data.NodeGroups, apiResp.CreateK8SEnv.Spec.NodeGroups)
+	resp.Diagnostics.Append(diags...)
 	data.Id = data.Name
 	data.NodeGroups, diags = nodeGroupsToModel(apiResp.CreateK8SEnv.Spec.NodeGroups)
 	resp.Diagnostics.Append(diags...)
@@ -94,7 +95,8 @@ func (r *K8SEnvResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	// Reorder node groups  and zones to respect order in the user's configuration
-	apiResp.K8sEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.K8sEnv.Spec.NodeGroups)
+	apiResp.K8sEnv.Spec.NodeGroups, diags = reorderNodeGroups(ctx, data.NodeGroups, apiResp.K8sEnv.Spec.NodeGroups)
+	resp.Diagnostics.Append(diags...)
 	diags = data.toModel(apiResp.K8sEnv.Name, apiResp.K8sEnv.SpecRevision, *apiResp.K8sEnv.Spec)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -130,7 +132,8 @@ func (r *K8SEnvResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	apiResp.UpdateK8SEnv.Spec.NodeGroups = reorderNodeGroups(data.NodeGroups, apiResp.UpdateK8SEnv.Spec.NodeGroups)
+	apiResp.UpdateK8SEnv.Spec.NodeGroups, diags = reorderNodeGroups(ctx, data.NodeGroups, apiResp.UpdateK8SEnv.Spec.NodeGroups)
+	resp.Diagnostics.Append(diags...)
 	diags = data.toModel(name, apiResp.UpdateK8SEnv.SpecRevision, *apiResp.UpdateK8SEnv.Spec)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
The API returns `node_groups[*].zones` sorted. The provider reordered node groups and top-level `zones` to config order, but stored the nested zones list in API order, so non-alphabetical config zones failed with:

```
Error: Provider produced inconsistent result after apply
.node_groups[0].zones[0]: was cty.StringVal("us-east-1d"), but now cty.StringVal("us-east-1a")
```

Fix: reorder each node group's inner zones (`locations` for hcloud) to config order in Create/Read/Update across all envs.