### PR TITLE
fix: k8s load balancer annotations returned as empty list instead of null after apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.5](https://github.com/Altinity/terraform-provider-altinitycloud/compare/v0.7.4...v0.7.5)
+### Fixed
+- Fix `inconsistent result after apply` on `load_balancers.public/internal.annotations` in k8s environments when annotations are not set: the provider returned an empty list where the plan had null (regression in 0.7.3).
+
 ## [0.7.4](https://github.com/Altinity/terraform-provider-altinitycloud/compare/v0.7.2...v0.7.4)
 Re-release of 0.7.3, whose checksums recorded by the Terraform Registry do not match its release artifacts, breaking `terraform init`. Do not use 0.7.3.
+
+**Known issue:** k8s environments fail with `inconsistent result after apply` on `load_balancers.*.annotations` when annotations are not set; fixed in 0.7.5.
 
 ### Added
 - Support customer-managed KMS keys in AWS environments: `kms_key_arn` at the environment level (encrypts Altinity-provisioned data buckets and EBS volumes) and per bucket in `external_buckets` [#236](https://github.com/Altinity/terraform-provider-altinitycloud/pull/236).

--- a/internal/provider/env/common/mapper.go
+++ b/internal/provider/env/common/mapper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
+// SetToModel/ListToModel always return non-null; unsafe for plain Optional attrs where null must stay null.
 func SetToModel(input []string) (types.Set, diag.Diagnostics) {
 	zones := []attr.Value{}
 	for _, str := range input {
@@ -30,10 +31,7 @@ func ListToModel(input []string) (types.List, diag.Diagnostics) {
 	return list, diags
 }
 
-// CustomDomainsToSDK resolves the deprecated custom_domain and the custom_domains
-// list into SDK inputs. They are mutually exclusive at config level (enforced by a
-// ConflictsWith validator), so prefer the list when set and fall back to the
-// deprecated scalar otherwise. Both are unknown-safe (treated as "not set").
+// Prefers custom_domains over the deprecated custom_domain (mutually exclusive via validator); unknown-safe.
 func CustomDomainsToSDK(ctx context.Context, customDomain types.String, customDomains types.List) (*string, []string, diag.Diagnostics) {
 	var allDiags diag.Diagnostics
 
@@ -50,13 +48,9 @@ func CustomDomainsToSDK(ctx context.Context, customDomain types.String, customDo
 	return customDomain.ValueStringPointer(), nil, allDiags
 }
 
-// CustomDomainsToModel maps the API response back to the two mutually-exclusive
-// model fields for a resource Read. It is driven by prior state (priorCustomDomains):
-// if the user manages domains via the list, refresh the list and keep the deprecated
-// scalar null; otherwise mirror the deprecated scalar and keep the list null. This
-// avoids the API's customDomains[0] echo flipping a list-managed resource into a
-// permanent diff on the deprecated attribute. Data sources expose both fields
-// directly and must not use this helper.
+// Refreshes whichever field prior state manages and keeps the other null, so the
+// API's customDomains[0] echo can't flip a list-managed resource into a permanent
+// diff on the deprecated scalar. Resources only; data sources expose both fields.
 func CustomDomainsToModel(priorCustomDomains types.List, specCustomDomain *string, specCustomDomains []string) (types.String, types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -69,14 +63,13 @@ func CustomDomainsToModel(priorCustomDomains types.List, specCustomDomain *strin
 	return types.StringPointerValue(specCustomDomain), types.ListNull(types.StringType), diags
 }
 
-// DataSourceCustomDomainsToModel populates both the deprecated custom_domain and the
-// custom_domains list from the API response. Data sources are read-only and have no
-// "user intent" to preserve, so they expose the actual values of both attributes.
+// Data sources are read-only with no user intent to preserve, so expose both attributes as returned.
 func DataSourceCustomDomainsToModel(specCustomDomain *string, specCustomDomains []string) (types.String, types.List, diag.Diagnostics) {
 	list, diags := ListToModel(specCustomDomains)
 	return types.StringPointerValue(specCustomDomain), list, diags
 }
 
+// Always non-null; safe only while reservations attrs are Required or defaulted.
 func ReservationsToModel(input []client.NodeReservation) (types.Set, diag.Diagnostics) {
 	reservations := []attr.Value{}
 	for _, reservation := range input {

--- a/internal/provider/env/common/model.go
+++ b/internal/provider/env/common/model.go
@@ -36,14 +36,13 @@ type MaintenanceWindowModel struct {
 	Days          []types.String `tfsdk:"days"`
 }
 
-// ReorderByKey returns items reordered to match the order of model, pairing by
-// key. Matching is positional: each model entry consumes the first not-yet-used
-// item with the same key, so duplicate keys (valid for e.g. tolerations or
-// unnamed catalogs) pair in config order instead of collapsing to the first
-// match. Every item is emitted exactly once; items with no model counterpart
-// are appended at the end. The result always has len(items) elements — no
-// duplication, no loss.
+// ReorderByKey returns items in model (config) order, pairing by key; unmatched
+// items go last, duplicate keys pair positionally, nil stays nil (null in state).
 func ReorderByKey[M any, S any](model []M, items []S, getModelKey func(M) string, getItemKey func(S) string) []S {
+	if len(items) == 0 {
+		return items
+	}
+
 	ordered := make([]S, 0, len(items))
 	used := make([]bool, len(items))
 

--- a/internal/provider/env/common/model_test.go
+++ b/internal/provider/env/common/model_test.go
@@ -91,8 +91,31 @@ func TestReorderByKey(t *testing.T) {
 	}
 }
 
-// Duplicate keys (valid for tolerations, unnamed catalogs, same-named windows)
-// must not collapse to the first match or drop entries.
+// []T{} serializes as empty list, not null; nil must stay nil (v0.7.3 regression).
+func TestReorderByKeyNilPreserved(t *testing.T) {
+	type item struct{ Key string }
+	key := func(i item) string { return i.Key }
+
+	t.Run("nil items, empty model", func(t *testing.T) {
+		if got := ReorderByKey([]item(nil), []item(nil), key, key); got != nil {
+			t.Errorf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("nil items, non-empty model", func(t *testing.T) {
+		if got := ReorderByKey([]item{{Key: "a"}}, []item(nil), key, key); got != nil {
+			t.Errorf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("non-nil empty items stay non-nil", func(t *testing.T) {
+		if got := ReorderByKey([]item{{Key: "a"}}, []item{}, key, key); got == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+	})
+}
+
+// Duplicate keys must not collapse to the first match or drop entries.
 func TestReorderByKeyDuplicateKeys(t *testing.T) {
 	type item struct{ Key, Value string }
 

--- a/internal/provider/env/k8s/e2e_test.go
+++ b/internal/provider/env/k8s/e2e_test.go
@@ -9,18 +9,12 @@ import (
 	"github.com/altinity/terraform-provider-altinitycloud/internal/provider/test"
 )
 
-// TestE2EAltinityCloudEnvK8S drives create -> update against the dev control
-// plane using a dummy-prefixed env, asserting no drift after each apply. The
-// config exercises every settable field so the drift check validates the full
-// spec round-trip. Teardown is skipped (dev delete requires MFA).
+// Create -> update with every settable field, asserting no drift after each apply.
 func TestE2EAltinityCloudEnvK8S(t *testing.T) {
 	test.RunE2ELifecycle(t, "dummy-e2e-k8s-", k8sE2EConfig)
 }
 
-// k8sE2EConfig returns a BYOK env resource that sets every settable attribute.
-// capacity drives the mutable change exercised by the update step.
-//
-// Intentionally omitted: custom_domain (superseded by custom_domains).
+// capacity drives the update step; custom_domain omitted (superseded by custom_domains).
 func k8sE2EConfig(envName string, capacity int) string {
 	return fmt.Sprintf(`
 resource "%s" "dummy" {
@@ -134,6 +128,27 @@ resource "%s" "dummy" {
   force_destroy                   = true
   skip_deprovision_on_destroy     = true
   allow_delete_while_disconnected = true
+}
+`, RESOURCE_NAME, envName, capacity)
+}
+
+// Required attrs only: covers default/null round-trips the maximal config can't.
+func TestE2EAltinityCloudEnvK8SMinimal(t *testing.T) {
+	test.RunE2ELifecycle(t, "dummy-e2e-k8s-min-", k8sE2EMinimalConfig)
+}
+
+func k8sE2EMinimalConfig(envName string, capacity int) string {
+	return fmt.Sprintf(`
+resource "%s" "dummy" {
+  name         = "%s"
+  distribution = "CUSTOM"
+
+  node_groups = [{
+    node_type         = "small"
+    zones             = ["us-east-1a"]
+    capacity_per_zone = %d
+    reservations      = ["SYSTEM", "CLICKHOUSE", "ZOOKEEPER"]
+  }]
 }
 `, RESOURCE_NAME, envName, capacity)
 }

--- a/internal/provider/env/k8s/model.go
+++ b/internal/provider/env/k8s/model.go
@@ -156,8 +156,7 @@ func (model *K8SEnvResourceModel) toModel(name string, specRevision int64, spec 
 	model.CustomDomain = customDomain
 	model.CustomDomains = customDomains
 	model.LoadBalancingStrategy = types.StringValue(string(spec.LoadBalancingStrategy))
-	// Reorder custom node types to respect order in the user's configuration; the
-	// API may return them in a different order, which would otherwise drift.
+	// API may return list fields out of config order, which would drift.
 	spec.CustomNodeTypes = common.ReorderByKey(model.CustomNodeTypes, spec.CustomNodeTypes,
 		func(m NodeTypeModel) string { return m.Name.ValueString() },
 		func(s *client.K8SEnvSpecFragment_CustomNodeTypes) string { return s.Name },
@@ -168,7 +167,6 @@ func (model *K8SEnvResourceModel) toModel(name string, specRevision int64, spec 
 	model.NodeGroups = nodeGroups
 	model.LoadBalancers = loadBalancersToModel(spec.LoadBalancers, model.LoadBalancers)
 	model.Logs = logsToModel(spec.Logs)
-	// Reorder maintenance windows the API may return out of config order, to avoid drift.
 	spec.MaintenanceWindows = common.ReorderByKey(model.MaintenanceWindows, spec.MaintenanceWindows,
 		func(m common.MaintenanceWindowModel) string { return m.Name.ValueString() },
 		func(s *client.K8SEnvSpecFragment_MaintenanceWindows) string { return s.Name },
@@ -218,14 +216,8 @@ func reorderAnnotations(config, items []common.KeyValueModel) []common.KeyValueM
 
 func loadBalancersToModel(loadBalancers client.K8SEnvSpecFragment_LoadBalancers, config *LoadBalancersModel) *LoadBalancersModel {
 	model := &LoadBalancersModel{
-		Public: &PublicLoadBalancerModel{
-			Annotations: []common.KeyValueModel{},
-			Enabled:     types.BoolValue(false),
-		},
-		Internal: &InternalLoadBalancerModel{
-			Annotations: []common.KeyValueModel{},
-			Enabled:     types.BoolValue(false),
-		},
+		Public:   &PublicLoadBalancerModel{},
+		Internal: &InternalLoadBalancerModel{},
 	}
 
 	// TODO: Create helper to extract annotations and source ip ranges
@@ -467,10 +459,7 @@ func maintenanceWindowsToModel(input []*client.K8SEnvSpecFragment_MaintenanceWin
 	return maintenanceWindow
 }
 
-// nodeGroupMatches pairs a config node group with an API one. When the user
-// set a name it is the unique identity (so two groups sharing a node_type but
-// differing by name pair correctly); otherwise name is server-computed and may
-// differ from the node type, so we fall back to matching on node_type.
+// User-set name is the unique identity; otherwise name is server-computed, so match on node_type.
 func nodeGroupMatches(m NodeGroupsModel, s *client.K8SEnvSpecFragment_NodeGroups) bool {
 	if name := m.Name.ValueString(); name != "" {
 		return name == s.Name
@@ -478,11 +467,7 @@ func nodeGroupMatches(m NodeGroupsModel, s *client.K8SEnvSpecFragment_NodeGroups
 	return m.NodeType.ValueString() == s.NodeType
 }
 
-// reorderNodeGroups returns the API node groups in config order: each config
-// group pulls its match to the front, then any API-only groups follow.
-// selectorKey/tolerationKey build a composite identity from all fields so
-// entries that share a key (valid for both) reorder by full identity instead of
-// collapsing on key alone. \x1f (unit separator) can't appear in these values.
+// Composite identity from all fields so entries sharing a key don't collapse; \x1f can't appear in these values.
 func selectorKey(key, value string) string {
 	return key + "\x1f" + value
 }

--- a/internal/provider/env/k8s/model_test.go
+++ b/internal/provider/env/k8s/model_test.go
@@ -781,6 +781,23 @@ func TestLoadBalancersToModel(t *testing.T) {
 	}
 }
 
+// v0.7.3 regression: reordering must not turn nil (null) annotations into [].
+func TestLoadBalancersToModelNullAnnotationsStayNull(t *testing.T) {
+	config := &LoadBalancersModel{
+		Public:   &PublicLoadBalancerModel{Enabled: types.BoolValue(false)},
+		Internal: &InternalLoadBalancerModel{Enabled: types.BoolValue(false)},
+	}
+
+	result := loadBalancersToModel(client.K8SEnvSpecFragment_LoadBalancers{}, config)
+
+	if result.Public.Annotations != nil {
+		t.Errorf("Public annotations: expected nil, got %#v", result.Public.Annotations)
+	}
+	if result.Internal.Annotations != nil {
+		t.Errorf("Internal annotations: expected nil, got %#v", result.Internal.Annotations)
+	}
+}
+
 func TestNodeGroupsToSDK(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Fixes `Provider produced inconsistent result after apply` on `load_balancers.public/internal.annotations` for every k8s env apply where annotations are not set (regression from #244, shipped in v0.7.3/v0.7.4).

**Root cause:** the schema default objects make `config.Public/Internal` non-nil even when unset, so annotation reordering always runs — and `ReorderByKey` allocated an empty slice for nil input, turning null annotations into `[]` in state.

**Fix:** `ReorderByKey` returns empty input as-is, preserving nil across all call sites.

Also adds nil-preservation unit tests (they fail on master with the exact production error) and `TestE2EAltinityCloudEnvK8SMinimal`, a required-fields-only e2e lifecycle that exercises schema defaults and null round-trips — the existing maximal config can't catch omission bugs.